### PR TITLE
Added a tag to the docker task

### DIFF
--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -41,7 +41,7 @@ pipeline {
             }
             steps {
                 sh 'docker login -u $DOCKER_LOGIN_USR -p $DOCKER_LOGIN_PSW'
-                sh 'docker push codice/samlconf'
+                sh 'docker push codice/samlconf:latest'
             }
         }
     }

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -20,4 +20,5 @@ task docker(type: DockerBuildImage) {
     dependsOn copyDistribution
     dockerFile = file('Dockerfile')
     inputDir = file("$projectDir")
+    tag = 'codice/samlconf:latest'
 }


### PR DESCRIPTION
Jenkins was having an issue deploying to docker hub.
`15:22:47 An image does not exist locally with the tag: codice/samlconf`

Adding a tag to the docker task when we build an image and specifying that image name in the Jenkinsfile fixes it.