### PR TITLE
ktlint formatter added and resolved findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ OPTIONS
 > In order for the test kit to execute properly, you must configure both the test kit's and your IdP's/SP's metadata, as well as implement plugins
 for the user-handled portions of SAML profiles. See "Metadata" and "Plugins" for instructions.
 
+### Formatting
+If during development the build fails due to `format violations` run the following command to format:
+
+    gradle spotlessApply
+
 ### Metadata
 * If testing an IdP:
   * Provide your IdP's metadata file path to the `samlconf` script using `-i` or `--idpMetadata`.

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.2.30'
     id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC6-4'
+    id 'com.diffplug.gradle.spotless' version '3.10.0'
 }
 
 description = 'SAML Conformance Test Kit'
@@ -41,6 +42,7 @@ subprojects {
     apply plugin: 'kotlin-kapt'
     apply plugin: 'kotlin'
     apply plugin: 'com.bmuschko.docker-remote-api'
+    apply plugin: 'com.diffplug.gradle.spotless'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -61,6 +63,14 @@ subprojects {
         compile "com.jayway.restassured:rest-assured:$rest_assured_version"
         compile "org.slf4j:slf4j-api:$org_slf4j_version"
         compile "com.google.guava:guava:$guava_version"
+    }
+
+    spotless {
+        kotlin {
+            ktlint()
+
+            licenseHeaderFile rootProject.file('spotless.license.kt')
+        }
     }
 }
 

--- a/distribution/command-line/src/main/kotlin/org/codice/ckt/Command.kt
+++ b/distribution/command-line/src/main/kotlin/org/codice/ckt/Command.kt
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.ckt
 
 import org.codice.compliance.IDP_METADATA_PROPERTY

--- a/distribution/suites/src/main/kotlin/org/codice/compliance/tests/suites/BasicTestsSuite.kt
+++ b/distribution/suites/src/main/kotlin/org/codice/compliance/tests/suites/BasicTestsSuite.kt
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.compliance.tests.suites
 
 import org.codice.compliance.web.sso.PostLoginTest

--- a/library/src/main/kotlin/org/codice/compliance/SAMLComplianceException.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLComplianceException.kt
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.compliance
 
 class SAMLComplianceException : Exception {

--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.compliance
 
 /**
@@ -225,7 +238,6 @@ enum class SAMLSpecRefMessage(val message: String) {
     SAMLCore_6_1_b("The <EncryptedData> element's Type attribute SHOULD be used and, if it is present, MUST have the " +
             "value http://www.w3.org/2001/04/xmlenc#Element."),
 
-
     /***************
      *
      * BINDINGS
@@ -319,7 +331,6 @@ enum class SAMLSpecRefMessage(val message: String) {
 
 //    todo SAMLBindings_3_5_4_b("If a “RelayState” value is to accompany the SAML protocol message, it MUST be placed in
 // an additional hidden form control named RelayState within the same form with the SAML message."),
-
 
 //    todo SAMLBindings_3_5_4_c("SAML message could not be decoded. SAML messages should be base-64 encoded."),
 

--- a/plugins/ddf-plugins/src/main/kotlin/org/codice/compliance/saml/plugin/ddf/IdpResponderProvider.kt
+++ b/plugins/ddf-plugins/src/main/kotlin/org/codice/compliance/saml/plugin/ddf/IdpResponderProvider.kt
@@ -25,7 +25,6 @@ import org.codice.compliance.saml.plugin.IdpResponder
 import org.codice.security.saml.SamlProtocol
 import org.kohsuke.MetaInfServices
 
-
 @MetaInfServices
 class IdpResponderProvider : IdpResponder {
     companion object {
@@ -127,7 +126,7 @@ class IdpResponderProvider : IdpResponder {
                 .replace("window.idpState = ", "")
                 .replace(";", "")
 
-        val queryParams : MutableMap<String, String> =
+        val queryParams: MutableMap<String, String> =
                 Gson().fromJson(idpState, object : TypeToken<Map<String, String>>() {}.type)
 
         queryParams["AuthMethod"] = "up"

--- a/spotless.license.kt
+++ b/spotless.license.kt
@@ -11,12 +11,3 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.compliance.verification.binding
-
-abstract class BindingVerifier {
-    companion object {
-        const val MAX_RELAYSTATE_LEN = 80
-    }
-
-    abstract fun verifyBinding()
-}

--- a/test/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -31,7 +31,7 @@ import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 import org.w3c.dom.Node
 import java.io.File
 import java.net.URLClassLoader
-import java.util.*
+import java.util.ServiceLoader
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.reflect.KClass
 
@@ -114,7 +114,7 @@ class TestCommon {
                     .map { it.toURL() }
                     .toList()
 
-            check(jarUrls.isNotEmpty()) { "No plugins found in $PLUGIN_DIR_PROPERTY; CTK can not operate."}
+            check(jarUrls.isNotEmpty()) { "No plugins found in $PLUGIN_DIR_PROPERTY; CTK can not operate." }
             return URLClassLoader(jarUrls.toTypedArray(), SAMLComplianceException::class.java.classLoader)
         }
     }

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/ResponseVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/ResponseVerifier.kt
@@ -11,12 +11,10 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-
 package org.codice.compliance.verification
 
 import io.kotlintest.matchers.shouldNotBe
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.saml.plugin.IdpPostResponse
 import org.codice.compliance.saml.plugin.IdpRedirectResponse
 import org.codice.compliance.saml.plugin.IdpResponse
@@ -30,6 +28,9 @@ import org.codice.security.sign.Decoder.InflationException.InflErrorCode
 import org.w3c.dom.Node
 import java.io.IOException
 
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
+
 sealed class ResponseVerifier(val response: IdpResponse) {
 
     internal fun verifyResponse(): Node {
@@ -42,7 +43,6 @@ sealed class ResponseVerifier(val response: IdpResponse) {
 
     protected abstract fun decodeResponse(response: IdpResponse): String
     protected abstract fun getBindingVerifier(response: IdpResponse): BindingVerifier
-
 }
 
 class RedirectResponseVerifier(response: IdpResponse) : ResponseVerifier(response) {

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/PostVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/PostVerifier.kt
@@ -15,10 +15,12 @@ package org.codice.compliance.verification.binding
 
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SIGNATURE
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.children
 import org.codice.compliance.saml.plugin.IdpPostResponse
 import org.codice.compliance.utils.TestCommon.Companion.EXAMPLE_RELAY_STATE
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 class PostVerifier(val response: IdpPostResponse) : BindingVerifier() {
     /**

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectVerifier.kt
@@ -15,7 +15,6 @@ package org.codice.compliance.verification.binding
 
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_RESPONSE
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.children
 import org.codice.compliance.saml.plugin.IdpRedirectResponse
 import org.codice.compliance.utils.TestCommon.Companion.ACS_URL
@@ -26,6 +25,9 @@ import org.codice.security.sign.SimpleSign.SignatureException.SigErrorCode
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 class RedirectVerifier(val response: IdpRedirectResponse) : BindingVerifier() {
     /**

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
@@ -16,12 +16,14 @@ package org.codice.compliance.verification.core
 import org.apache.commons.lang3.StringUtils
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLSpecRefMessage
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.utils.TestCommon.Companion.XSI
 import org.w3c.dom.Node
 import java.net.URI
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 const val FOUR_DIGIT_YEAR_LEN = 4
 

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -15,11 +15,13 @@ package org.codice.compliance.verification.core
 
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SIGNATURE
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.ELEMENT
 import org.w3c.dom.Node
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 class CoreVerifier(val node: Node) {
     /**

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/core/LogoutRequestProtocolVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/core/LogoutRequestProtocolVerifier.kt
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.compliance.verification.core
 
 import org.codice.compliance.SAMLComplianceException
@@ -21,7 +34,6 @@ class LogoutRequestProtocolVerifier(val request: Node) {
                 throw SAMLComplianceException.createWithPropertyReqMessage("SAMLCore.3.7.1",
                         "BaseID or NameID or EncryptedID",
                         "LogoutRequest")
-
         }
     }
 }

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/core/RequestProtocolVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/core/RequestProtocolVerifier.kt
@@ -14,10 +14,12 @@
 package org.codice.compliance.verification.core
 
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
 import org.w3c.dom.Node
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 class RequestProtocolVerifier(val request: Node) {
     /**

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseProtocolVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseProtocolVerifier.kt
@@ -14,11 +14,13 @@
 package org.codice.compliance.verification.core
 
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.ACS_URL
 import org.w3c.dom.Node
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 class ResponseProtocolVerifier(val response: Node, val id: String) {
     companion object {

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/core/SamlAssertionsVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/core/SamlAssertionsVerifier.kt
@@ -15,13 +15,15 @@ package org.codice.compliance.verification.core
 
 import org.apache.commons.lang3.StringUtils
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.ELEMENT
 import org.codice.compliance.utils.TestCommon.Companion.XSI
 import org.w3c.dom.Node
 import java.time.Instant
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 @Suppress("LargeClass", "TooManyFunctions"
 /* Core assertion verification is a complex, but single responsibility issue. */)
@@ -166,7 +168,6 @@ class SamlAssertionsVerifier(val node: Node) {
                         message = "Multiple Keys found within the KeyInfo element.")
         }
     }
-
 
     /**
      * Verify the <Conditions> element against the Core Spec

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
@@ -15,7 +15,6 @@ package org.codice.compliance.verification.profile
 
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SIGNATURE
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.ACS_URL
 import org.codice.compliance.utils.TestCommon.Companion.ID
@@ -23,6 +22,9 @@ import org.codice.compliance.utils.TestCommon.Companion.SP_ISSUER
 import org.codice.compliance.utils.TestCommon.Companion.idpMetadata
 import org.opensaml.saml.saml2.metadata.impl.EntityDescriptorImpl
 import org.w3c.dom.Node
+
+/* ktlint-disable no-wildcard-imports */
+import org.codice.compliance.SAMLSpecRefMessage.*
 
 class SingleSignOnProfileVerifier(val response: Node) {
     /**

--- a/test/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
+++ b/test/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
@@ -30,8 +30,6 @@ import org.codice.compliance.verification.verifyResponse
 import org.codice.security.saml.SamlProtocol
 import org.codice.security.sign.Encoder
 
-
-
 class PostLoginTest : StringSpec() {
     companion object {
         const val HTTP_OK = 200

--- a/test/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
+++ b/test/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
@@ -17,7 +17,6 @@ import com.google.common.io.Resources.getResource
 import com.jayway.restassured.RestAssured
 import com.jayway.restassured.RestAssured.given
 import io.kotlintest.specs.StringSpec
-import org.apache.cxf.rs.security.saml.sso.SSOConstants.*
 import org.codice.compliance.Common
 import org.codice.compliance.saml.plugin.IdpResponder
 import org.codice.compliance.utils.TestCommon
@@ -34,6 +33,9 @@ import org.codice.security.saml.SamlProtocol
 import org.codice.security.sign.Encoder
 import org.codice.security.sign.SimpleSign
 import java.time.Instant
+
+/* ktlint-disable no-wildcard-imports */
+import org.apache.cxf.rs.security.saml.sso.SSOConstants.*
 
 class RedirectLoginTest : StringSpec() {
     companion object {


### PR DESCRIPTION
Adds a formatter to the project and addresses formatting findings. Readme updated as well.

Using the Spotless project (https://github.com/diffplug/spotless/tree/master/plugin-gradle) which has ktlint (https://ktlint.github.io/) support and license header enforcement. 

Running `gradle build` will run the formatter. Any errors can be resolved by running `gradle spotlessApply`.