### PR TITLE
Profiles 3.1 - Holder of Key Verification

### DIFF
--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -14,6 +14,17 @@ enum class SAMLSpecRefMessage(val message: String) {
      *
      ***************/
 
+    SAMLProfiles_3_1_a("One or more <ds:KeyInfo> elements MUST be present within the <SubjectConfirmationData> " +
+            "element."),
+
+    SAMLProfiles_3_1_b("An xsi:type attribute MAY be present in the <SubjectConfirmationData> element and, " +
+            "if present, MUST be set to saml:KeyInfoConfirmationDataType (the namespace prefix is arbitrary " +
+            "but must reference the SAML assertion namespace)."),
+
+    SAMLProfiles_3_1_c("Note that in accordance with [XMLSig], each <ds:KeyInfo> element MUST identify a single " +
+            "cryptographic key. Multiple keys MAY be identified with separate <ds:KeyInfo> elements, such as when " +
+            "different confirmation keys are needed for different relying parties."),
+
     SAMLProfiles_4_1_4_2_a("If the <Response> message is signed or if an enclosed assertion is encrypted, then the " +
             "<Issuer> element MUST be present."),
 

--- a/test/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -29,13 +29,15 @@ import org.opensaml.saml.saml2.core.impl.IssuerBuilder
 import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 import java.io.File
 import java.net.URLClassLoader
-import java.util.*
+import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
 class TestCommon {
     companion object {
         const val XSI = "http://www.w3.org/2001/XMLSchema-instance"
         const val ELEMENT = "http://www.w3.org/2001/04/xmlenc#Element"
+        const val SAML_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:assertion"
+        const val HOLDER_OF_KEY_URI = "urn:oasis:names:tc:SAML:2.0:cm:holder-of-key"
         const val ID = "a1chfeh0234hbifc1jjd3cb40ji0d49"
         const val EXAMPLE_RELAY_STATE = "relay+State"
         const val INCORRECT_RELAY_STATE = "RelayStateLongerThan80CharsIsIncorrectAccordingToTheSamlSpec" +

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
@@ -53,7 +53,7 @@ class ProfilesVerifier(private val node: Node) {
                         message = "<ds:KeyInfo> not found within the <SubjectConfirmationData> element.")
 
             keyInfos.forEach {
-                if (it.childNodes.length > 1)
+                if (it.children("KeyValue").size > 1)
                     throw SAMLComplianceException.create(SAMLProfiles_3_1_c,
                             message = "<ds:KeyInfo> must not have multiple values.")
             }

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.profile
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_3_1_a
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_3_1_b
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_3_1_c
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.utils.TestCommon.Companion.HOLDER_OF_KEY_URI
+import org.codice.compliance.utils.TestCommon.Companion.SAML_NAMESPACE
+import org.codice.compliance.utils.TestCommon.Companion.XSI
+import org.w3c.dom.Node
+
+class ProfilesVerifier(private val node: Node) {
+    /**
+     * Verify response against the Profiles Spec document
+     */
+    fun verify() {
+        verifyHolderOfKey()
+    }
+
+    private fun verifyHolderOfKey() {
+        val subjectConfirmationDataList = node.allChildren("SubjectConfirmation")
+                .filter { it.attributes.getNamedItem("Method").textContent == HOLDER_OF_KEY_URI }
+                .flatMap { it.children("SubjectConfirmationData") }
+
+        subjectConfirmationDataList.forEach {
+            val type = it.attributes.getNamedItemNS(XSI, "type")
+            if (type != null && !type.textContent.contains("KeyInfoConfirmationDataType"))
+                throw SAMLComplianceException.createWithPropertyNotEqualMessage(SAMLProfiles_3_1_b,
+                        "type", type.textContent, "KeyInfoConfirmationDataType")
+
+            if (type.firstChild.namespaceURI != SAML_NAMESPACE)
+                throw SAMLComplianceException.createWithPropertyNotEqualMessage(SAMLProfiles_3_1_b,
+                        "the namespace prefix", type.firstChild.namespaceURI, SAML_NAMESPACE)
+
+            val keyInfos = it.children("KeyInfo")
+            if (keyInfos.isEmpty())
+                throw SAMLComplianceException.create(SAMLProfiles_3_1_a,
+                        message = "<ds:KeyInfo> not found within the <SubjectConfirmationData> element.")
+
+            keyInfos.forEach {
+                if (it.childNodes.length > 1)
+                    throw SAMLComplianceException.create(SAMLProfiles_3_1_c,
+                            message = "<ds:KeyInfo> must not have multiple values.")
+            }
+        }
+    }
+}

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
@@ -15,7 +15,16 @@ package org.codice.compliance.verification.profile
 
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SIGNATURE
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage.*
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_a
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_b
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_c
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_d
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_f
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_g
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_h
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_i
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_j
+import org.codice.compliance.SAMLSpecRefMessage.SAMLProfiles_4_1_4_2_k
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.ACS_URL
 import org.codice.compliance.utils.TestCommon.Companion.ID
@@ -32,6 +41,7 @@ class SingleSignOnProfileVerifier(val response: Node) {
     fun verify() {
         verifyIssuer()
         verifySsoAssertions()
+        ProfilesVerifier(response).verify()
     }
 
     /**


### PR DESCRIPTION
```
One or more <ds:KeyInfo> elements MUST be present within the <SubjectConfirmationData> 
element. An xsi:type attribute MAY be present in the <SubjectConfirmationData> element 
and, if present, MUST be set to saml:KeyInfoConfirmationDataType (the namespace prefix 
is arbitrary but must reference the SAML assertion namespace).

Note that in accordance with [XMLSig], each <ds:KeyInfo> element MUST identify a 
single cryptographic key. Multiple keys MAY be identified with separate <ds:KeyInfo> 
elements, such as when different confirmation keys are needed for different relying parties.
```