### PR TITLE
Removes the Sherter google-java-format plugin, deferring to Spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.2.30'
     id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC6-4'
     id 'com.diffplug.gradle.spotless' version '3.10.0'
-    id 'com.github.sherter.google-java-format' version '0.6'
     id 'net.ltgt.errorprone' version '0.0.13'
 }
 
@@ -47,7 +46,6 @@ subprojects {
     apply plugin: 'kotlin'
     apply plugin: 'com.bmuschko.docker-remote-api'
     apply plugin: 'com.diffplug.gradle.spotless'
-    apply plugin: "com.github.sherter.google-java-format"
     apply plugin: 'net.ltgt.errorprone'
 
     compileJava.options.encoding = "$java_encoding"
@@ -74,6 +72,11 @@ subprojects {
     }
 
     spotless {
+        java {
+            licenseHeaderFile rootProject.file('codice.license.kt')
+            trimTrailingWhitespace()
+            googleJavaFormat()
+        }
         kotlin {
             ktlint()
             licenseHeaderFile rootProject.file('codice.license.kt')

--- a/detekt.yml
+++ b/detekt.yml
@@ -300,7 +300,7 @@ style:
     ignoreNamedArgument: true
     ignoreEnums: false
   MaxLineLength:
-    active: true
+    active: false
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false

--- a/plugins/plugins-api/src/main/java/org/codice/compliance/saml/plugin/IdpResponse.java
+++ b/plugins/plugins-api/src/main/java/org/codice/compliance/saml/plugin/IdpResponse.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.compliance.saml.plugin;
 
 public abstract class IdpResponse {


### PR DESCRIPTION
Also turns off the line-length check in detekt. We will eventually (hopefully) have line length managed through Spotless (for both Java and Kotlin files) but now will deal with that through IDE or manually.