### PR TITLE
Removes the shouldBe checks on the status codes

### DIFF
--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
@@ -14,8 +14,8 @@
 package org.codice.compliance.verification.binding
 
 import com.google.api.client.http.HttpStatusCodes
+import org.codice.compliance.SAMLBindings_3_5_6_a
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLSpecRefMessage
 
 open class BindingVerifier {
     companion object {
@@ -28,7 +28,7 @@ open class BindingVerifier {
         fun verifyHttpStatusCode(code: Int) {
             if (code >= HTTP_ERROR_THRESHOLD) {
                 throw SAMLComplianceException.createWithPropertyMessage(
-                        SAMLSpecRefMessage.SAMLBindings_3_5_6_a,
+                        SAMLBindings_3_5_6_a,
                         property = "HTTP Status Code",
                         actual = code.toString(),
                         expected = "${HttpStatusCodes.STATUS_CODE_OK}"

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
@@ -13,7 +13,6 @@
  */
 package org.codice.compliance.verification.binding
 
-import com.google.api.client.http.HttpStatusCodes
 import org.codice.compliance.SAMLBindings_3_5_6_a
 import org.codice.compliance.SAMLComplianceException
 
@@ -31,7 +30,7 @@ open class BindingVerifier {
                         SAMLBindings_3_5_6_a,
                         property = "HTTP Status Code",
                         actual = code.toString(),
-                        expected = "${HttpStatusCodes.STATUS_CODE_OK}"
+                        expected = "A non-error http status code, i.e. less than $HTTP_ERROR_THRESHOLD"
                 )
             }
         }

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.binding
+
+import com.google.api.client.http.HttpStatusCodes
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLSpecRefMessage
+
+open class BindingVerifier {
+    companion object {
+        private const val HTTP_ERROR_THRESHOLD = 400
+        /**
+         * Verifies the http status code of the response is not an error status code
+         * according to the binding spec
+         * 3.4.6 & 3.5.6 Error Reporting
+         */
+        fun verifyHttpStatusCode(code: Int) {
+            if (code >= HTTP_ERROR_THRESHOLD) {
+                throw SAMLComplianceException.createWithPropertyMessage(
+                        SAMLSpecRefMessage.SAMLBindings_3_5_6_a,
+                        property = "HTTP Status Code",
+                        actual = code.toString(),
+                        expected = "${HttpStatusCodes.STATUS_CODE_OK}"
+                )
+            }
+        }
+    }
+}

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
@@ -42,12 +42,29 @@ import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.codice.security.sign.Decoder
 
 class PostBindingVerifier(private val response: IdpPostResponseDecorator) {
+    companion object {
+        /**
+         * Verifies the http status code of the response according to the post binding rules in the post spec
+         * 3.5.6 Error Reporting
+         */
+        fun verifyHttpStatusCode(code: Int) {
+            if (code != HttpStatusCodes.STATUS_CODE_OK) {
+                throw SAMLComplianceException.createWithPropertyMessage(
+                        SAMLBindings_3_5_6_a,
+                        property = "HTTP Status Code",
+                        actual = code.toString(),
+                        expected = "${HttpStatusCodes.STATUS_CODE_OK}"
+                )
+            }
+        }
+    }
+
     /**
      * Verify the response for a post binding
      */
     fun verify() {
+        verifyHttpStatusCode(response.httpStatusCode)
         verifyNoNulls()
-        verifyHttpStatusCode()
         decodeAndVerify()
         verifyPostSSO()
         if (response.isRelayStateGiven || response.relayState != null) {
@@ -86,21 +103,6 @@ class PostBindingVerifier(private val response: IdpPostResponseDecorator) {
                         SAMLBindings_3_5_4_c,
                         message = "The RelayState within the RelayState form control could not be found.")
             }
-        }
-    }
-
-    /**
-     * Verifies the http status code of the response according to the post binding rules in the post spec
-     * 3.5.6 Error Reporting
-     */
-    private fun verifyHttpStatusCode() {
-        if (response.httpStatusCode != HttpStatusCodes.STATUS_CODE_OK) {
-            SAMLComplianceException.createWithPropertyMessage(
-                    SAMLBindings_3_5_6_a,
-                    property = "HTTP Status Code",
-                    actual = response.httpStatusCode.toString(),
-                    expected = "${HttpStatusCodes.STATUS_CODE_OK}"
-            )
         }
     }
 

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
@@ -13,7 +13,6 @@
  */
 package org.codice.compliance.verification.binding
 
-import com.google.api.client.http.HttpStatusCodes
 import de.jupf.staticlog.Log
 import io.kotlintest.matchers.shouldNotBe
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.RELAY_STATE
@@ -27,7 +26,6 @@ import org.codice.compliance.SAMLBindings_3_5_4_c
 import org.codice.compliance.SAMLBindings_3_5_4_d1
 import org.codice.compliance.SAMLBindings_3_5_4_d2
 import org.codice.compliance.SAMLBindings_3_5_5_2_a
-import org.codice.compliance.SAMLBindings_3_5_6_a
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLProfiles_4_1_4_5
 import org.codice.compliance.allChildren
@@ -41,24 +39,7 @@ import org.codice.compliance.utils.decorators.IdpPostResponseDecorator
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.codice.security.sign.Decoder
 
-class PostBindingVerifier(private val response: IdpPostResponseDecorator) {
-    companion object {
-        /**
-         * Verifies the http status code of the response according to the post binding rules in the post spec
-         * 3.5.6 Error Reporting
-         */
-        fun verifyHttpStatusCode(code: Int) {
-            if (code != HttpStatusCodes.STATUS_CODE_OK) {
-                throw SAMLComplianceException.createWithPropertyMessage(
-                        SAMLBindings_3_5_6_a,
-                        property = "HTTP Status Code",
-                        actual = code.toString(),
-                        expected = "${HttpStatusCodes.STATUS_CODE_OK}"
-                )
-            }
-        }
-    }
-
+class PostBindingVerifier(private val response: IdpPostResponseDecorator) : BindingVerifier() {
     /**
      * Verify the response for a post binding
      */

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
@@ -58,32 +58,13 @@ import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
-class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator) {
-    companion object {
-        /**
-         * Verifies the http status code of the response according to the redirect binding rules in the binding spec
-         * 3.4.6 Error Reporting
-         */
-        fun verifyHttpStatusCode(code: Int) {
-            // TODO remove the 200 check when "Manually change DDF IdP to respond with 302/303 status code for Redirect" is completed
-            if (code != HttpStatusCodes.STATUS_CODE_OK
-                    && code != HttpStatusCodes.STATUS_CODE_FOUND
-                    && code != HttpStatusCodes.STATUS_CODE_SEE_OTHER) {
-                throw SAMLComplianceException.createWithPropertyMessage(
-                        SAMLSpecRefMessage.SAMLBindings_3_4_6_a,
-                        property = "HTTP Status Code",
-                        actual = code.toString(),
-                        expected = "${HttpStatusCodes.STATUS_CODE_FOUND} or ${HttpStatusCodes.STATUS_CODE_SEE_OTHER}"
-                )
-            }
-        }
-    }
+class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator) : BindingVerifier() {
 
     /**
      * Verify the response for a redirect binding
      */
     fun verify() {
-        verifyHttpStatusCode(response.httpStatusCode)
+        verifyHttpRedirectStatusCode()
         verifyNoNulls()
         decodeAndVerify()
         verifyNoXMLSig()
@@ -93,6 +74,24 @@ class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator
         response.signature?.let {
             verifyRedirectSignature()
             verifyRedirectDestination()
+        }
+    }
+
+    /**
+     * Verifies the http status code of the response according to the redirect binding rules in the binding spec
+     * 3.4.6 Error Reporting
+     */
+    fun verifyHttpRedirectStatusCode() {
+        // TODO remove the 200 check when "Manually change DDF IdP to respond with 302/303 status code for Redirect" is completed
+        if (response.httpStatusCode != HttpStatusCodes.STATUS_CODE_OK
+                && response.httpStatusCode != HttpStatusCodes.STATUS_CODE_FOUND
+                && response.httpStatusCode != HttpStatusCodes.STATUS_CODE_SEE_OTHER) {
+            throw SAMLComplianceException.createWithPropertyMessage(
+                    SAMLSpecRefMessage.SAMLBindings_3_4_6_a,
+                    property = "HTTP Status Code",
+                    actual = response.httpStatusCode.toString(),
+                    expected = "${HttpStatusCodes.STATUS_CODE_FOUND} or ${HttpStatusCodes.STATUS_CODE_SEE_OTHER}"
+            )
         }
     }
 

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
@@ -59,12 +59,32 @@ import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
 class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator) {
+    companion object {
+        /**
+         * Verifies the http status code of the response according to the redirect binding rules in the binding spec
+         * 3.4.6 Error Reporting
+         */
+        fun verifyHttpStatusCode(code: Int) {
+            // TODO remove the 200 check when "Manually change DDF IdP to respond with 302/303 status code for Redirect" is completed
+            if (code != HttpStatusCodes.STATUS_CODE_OK
+                    && code != HttpStatusCodes.STATUS_CODE_FOUND
+                    && code != HttpStatusCodes.STATUS_CODE_SEE_OTHER) {
+                throw SAMLComplianceException.createWithPropertyMessage(
+                        SAMLSpecRefMessage.SAMLBindings_3_4_6_a,
+                        property = "HTTP Status Code",
+                        actual = code.toString(),
+                        expected = "${HttpStatusCodes.STATUS_CODE_FOUND} or ${HttpStatusCodes.STATUS_CODE_SEE_OTHER}"
+                )
+            }
+        }
+    }
+
     /**
      * Verify the response for a redirect binding
      */
     fun verify() {
+        verifyHttpStatusCode(response.httpStatusCode)
         verifyNoNulls()
-        verifyHttpStatusCode()
         decodeAndVerify()
         verifyNoXMLSig()
         if (response.isRelayStateGiven || response.relayState != null) {
@@ -107,24 +127,6 @@ class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator
                         SAMLBindings_3_4_3_b1,
                         message = "RelayState not found.")
             }
-        }
-    }
-
-    /**
-     * Verifies the http status code of the response according to the redirect binding rules in the binding spec
-     * 3.4.6 Error Reporting
-     */
-    private fun verifyHttpStatusCode() {
-        // TODO remove the 200 check when "Manually change DDF IdP to respond with 302/303 status code for Redirect" is completed
-        if (response.httpStatusCode != HttpStatusCodes.STATUS_CODE_OK
-                && response.httpStatusCode != HttpStatusCodes.STATUS_CODE_FOUND
-                && response.httpStatusCode != HttpStatusCodes.STATUS_CODE_SEE_OTHER) {
-            SAMLComplianceException.createWithPropertyMessage(
-                    SAMLBindings_3_4_6_a,
-                    property = "HTTP Status Code",
-                    actual = response.httpStatusCode.toString(),
-                    expected = "${HttpStatusCodes.STATUS_CODE_FOUND} or ${HttpStatusCodes.STATUS_CODE_SEE_OTHER}"
-            )
         }
     }
 

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
@@ -87,7 +87,7 @@ class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator
                 && response.httpStatusCode != HttpStatusCodes.STATUS_CODE_FOUND
                 && response.httpStatusCode != HttpStatusCodes.STATUS_CODE_SEE_OTHER) {
             throw SAMLComplianceException.createWithPropertyMessage(
-                    SAMLSpecRefMessage.SAMLBindings_3_4_6_a,
+                    SAMLBindings_3_4_6_a,
                     property = "HTTP Status Code",
                     actual = response.httpStatusCode.toString(),
                     expected = "${HttpStatusCodes.STATUS_CODE_FOUND} or ${HttpStatusCodes.STATUS_CODE_SEE_OTHER}"

--- a/test/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
+++ b/test/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
@@ -29,7 +29,7 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorators.bindingVerifier
 import org.codice.compliance.utils.decorators.decorate
-import org.codice.compliance.verification.binding.PostBindingVerifier
+import org.codice.compliance.verification.binding.BindingVerifier
 import org.codice.compliance.verification.core.ResponseProtocolVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
@@ -86,7 +86,7 @@ class PostLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .post(Common.getSingleSignOnLocation(POST_BINDING))
-            PostBindingVerifier.verifyHttpStatusCode(response.statusCode)
+            BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             val idpResponse = getServiceProvider(IdpResponder::class)
                     .getIdpPostResponse(response).decorate()
@@ -109,7 +109,7 @@ class PostLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .post(Common.getSingleSignOnLocation(POST_BINDING))
-            PostBindingVerifier.verifyHttpStatusCode(response.statusCode)
+            BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             val idpResponse = getServiceProvider(IdpResponder::class)
                     .getIdpPostResponse(response).decorate().apply {
@@ -153,7 +153,7 @@ class PostLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .post(Common.getSingleSignOnLocation(POST_BINDING))
-            PostBindingVerifier.verifyHttpStatusCode(response.statusCode)
+            BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             val idpResponse = getServiceProvider(IdpResponder::class)
                     .getIdpPostResponse(response).decorate()

--- a/test/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
+++ b/test/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
@@ -16,7 +16,6 @@ package org.codice.compliance.web.sso
 import com.jayway.restassured.RestAssured
 import com.jayway.restassured.RestAssured.given
 import de.jupf.staticlog.Log
-import io.kotlintest.matchers.shouldBe
 import io.kotlintest.specs.StringSpec
 import org.apache.wss4j.common.saml.builder.SAML2Constants
 import org.codice.compliance.Common
@@ -30,6 +29,7 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorators.bindingVerifier
 import org.codice.compliance.utils.decorators.decorate
+import org.codice.compliance.verification.binding.PostBindingVerifier
 import org.codice.compliance.verification.core.ResponseProtocolVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
@@ -44,7 +44,6 @@ import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 
 class PostLoginTest : StringSpec() {
     companion object {
-        const val HTTP_OK = 200
 
         /** Sets up positive path tests.
          * @return A string representation of a valid encoded POST AuthnRequest.
@@ -87,8 +86,8 @@ class PostLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .post(Common.getSingleSignOnLocation(POST_BINDING))
+            PostBindingVerifier.verifyHttpStatusCode(response.statusCode)
 
-            response.statusCode shouldBe HTTP_OK
             val idpResponse = getServiceProvider(IdpResponder::class)
                     .getIdpPostResponse(response).decorate()
             idpResponse.bindingVerifier().verify()
@@ -110,8 +109,8 @@ class PostLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .post(Common.getSingleSignOnLocation(POST_BINDING))
+            PostBindingVerifier.verifyHttpStatusCode(response.statusCode)
 
-            response.statusCode shouldBe 200
             val idpResponse = getServiceProvider(IdpResponder::class)
                     .getIdpPostResponse(response).decorate().apply {
                         isRelayStateGiven = true
@@ -154,8 +153,8 @@ class PostLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .post(Common.getSingleSignOnLocation(POST_BINDING))
+            PostBindingVerifier.verifyHttpStatusCode(response.statusCode)
 
-            response.statusCode shouldBe HTTP_OK
             val idpResponse = getServiceProvider(IdpResponder::class)
                     .getIdpPostResponse(response).decorate()
             idpResponse.bindingVerifier().verify()

--- a/test/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
+++ b/test/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
@@ -33,6 +33,7 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorators.bindingVerifier
 import org.codice.compliance.utils.decorators.decorate
+import org.codice.compliance.verification.binding.RedirectBindingVerifier
 import org.codice.compliance.verification.core.ResponseProtocolVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
@@ -88,6 +89,7 @@ class RedirectLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .get(Common.getSingleSignOnLocation(REDIRECT_BINDING))
+            RedirectBindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             // Get response from plugin portion
             val idpResponse = getServiceProvider(IdpResponder::class)
@@ -115,6 +117,7 @@ class RedirectLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .get(Common.getSingleSignOnLocation(REDIRECT_BINDING))
+            RedirectBindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             // Get response from plugin portion
             val idpResponse = getServiceProvider(IdpResponder::class)
@@ -161,6 +164,7 @@ class RedirectLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .get(Common.getSingleSignOnLocation(REDIRECT_BINDING))
+            RedirectBindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             // Get response from plugin portion
             val idpResponse = getServiceProvider(IdpResponder::class)

--- a/test/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
+++ b/test/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
@@ -33,7 +33,7 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorators.bindingVerifier
 import org.codice.compliance.utils.decorators.decorate
-import org.codice.compliance.verification.binding.RedirectBindingVerifier
+import org.codice.compliance.verification.binding.BindingVerifier
 import org.codice.compliance.verification.core.ResponseProtocolVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
@@ -89,7 +89,7 @@ class RedirectLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .get(Common.getSingleSignOnLocation(REDIRECT_BINDING))
-            RedirectBindingVerifier.verifyHttpStatusCode(response.statusCode)
+            BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             // Get response from plugin portion
             val idpResponse = getServiceProvider(IdpResponder::class)
@@ -117,7 +117,7 @@ class RedirectLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .get(Common.getSingleSignOnLocation(REDIRECT_BINDING))
-            RedirectBindingVerifier.verifyHttpStatusCode(response.statusCode)
+            BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             // Get response from plugin portion
             val idpResponse = getServiceProvider(IdpResponder::class)
@@ -164,7 +164,7 @@ class RedirectLoginTest : StringSpec() {
                     .ifValidationFails()
                     .`when`()
                     .get(Common.getSingleSignOnLocation(REDIRECT_BINDING))
-            RedirectBindingVerifier.verifyHttpStatusCode(response.statusCode)
+            BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
             // Get response from plugin portion
             val idpResponse = getServiceProvider(IdpResponder::class)


### PR DESCRIPTION
Removes the shouldBe checks on the status codes and replaces the checks with our own in order to throw our own SAMLComplienceExceptions