### PR TITLE
Profiles - Verification for error response

### DIFF
--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -66,6 +66,7 @@ object SAMLProfiles_4_1_4_2_h : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_i : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_j : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_k : SAMLProfileRefMessage()
+object SAMLProfiles_4_1_4_2_l : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_5 : SAMLProfileRefMessage()
 
 //-----------------

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -55,6 +55,9 @@ SAMLProfiles_4_1_4_2_j=If the identity provider supports the Single Logout profi
 SAMLProfiles_4_1_4_2_k=Each bearer assertion MUST contain an <AudienceRestriction> including the \
   service provider's unique identifier as an <Audience>.
 
+SAMLProfiles_4_1_4_2_l=If the identity provider wishes to return an error, it MUST NOT include \
+  any assertions in the <Response> message.
+
 SAMLProfiles_4_1_4_5=If the HTTP POST binding is used to deliver the <Response>, [E26]each \
   assertion MUST be protected by a digital signature. This can be accomplished by signing each \
   individual element or by <Assertion> signing the <Response> element.

--- a/test/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
+++ b/test/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
@@ -17,14 +17,28 @@ import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLProfiles_3_1_a
 import org.codice.compliance.SAMLProfiles_3_1_b
 import org.codice.compliance.SAMLProfiles_3_1_c
+import org.codice.compliance.SAMLProfiles_4_1_4_2_l
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.HOLDER_OF_KEY_URI
 import org.codice.compliance.utils.TestCommon.Companion.SAML_NAMESPACE
 import org.codice.compliance.utils.TestCommon.Companion.XSI
+import org.codice.compliance.verification.core.CoreVerifier
 import org.w3c.dom.Node
 
 class ProfilesVerifier(private val node: Node) {
+
+    /**
+     * Verify Error Response against the Profiles document.
+     * This should be called explicitly if an error is expected.
+     */
+    fun verifyErrorResponse(){
+        if(node.allChildren("Assertion").isNotEmpty())
+            throw SAMLComplianceException.create(SAMLProfiles_4_1_4_2_l,
+                    message = "A Response must not have an assertion if it's an error response.",
+                    node = node)
+    }
+
     /**
      * Verify response against the Profiles Spec document
      */


### PR DESCRIPTION
```
Profiles 4.1.4.2:
If the identity provider wishes to return an error, it MUST NOT include any 
assertions in the <Response> message.
```