### PR TITLE
Added a depends on in docker copy task

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
 // Copy the distribution from the distribution module over to the build module
 task copyDistribution(type: Copy) {
+    dependsOn(':distribution:command-line:build')
     from project(':distribution:command-line').file("build/distributions/samlconf-${project_version}.tar")
     into 'build'
     rename { String fileName ->


### PR DESCRIPTION
I noticed that when doing a parallel docker build, the Dockerfile fails to copy the distribution because the `copyDistribution` runs before it is built.