### PR TITLE
Bindings_3.4.4 Adds negative test for incomplete SAMLRequest query argument

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -45,8 +45,7 @@ class TestCommon {
         const val INCORRECT_DESTINATION = "https://incorrect.destination.com"
 
         const val IDP_ERROR_RESPONSE_REMINDER_MESSAGE = "Make sure the IdP responds immediately " +
-                "with a correctly formatted SAML error response (See section 3.2.1 in the SAML " +
-                "Core specification)"
+                "with a SAML error response (See section 3.2.1 in the SAML Core specification)"
         const val REQUESTER = "urn:oasis:names:tc:SAML:2.0:status:Requester"
         const val VERSION_MISMATCH = "urn:oasis:names:tc:SAML:2.0:status:VersionMismatch"
         private const val SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success"

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
@@ -13,7 +13,7 @@
  */
 package org.codice.compliance.verification.binding
 
-import org.codice.compliance.SAMLBindings_3_5_6_a
+import org.codice.compliance.SAMLBindings_3_4_6_a1
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.utils.TestCommon.Companion.IDP_ERROR_RESPONSE_REMINDER_MESSAGE
 
@@ -29,10 +29,10 @@ abstract class BindingVerifier {
         fun verifyHttpStatusCode(code: Int) {
             if (code >= HTTP_ERROR_THRESHOLD) {
                 throw SAMLComplianceException.createWithPropertyMessage(
-                        SAMLBindings_3_5_6_a,
+                        SAMLBindings_3_4_6_a1,
                         property = "HTTP Status Code",
                         actual = code.toString(),
-                        expected = "A non-error http status code, i.e. less than " +
+                        expected = "a non-error http status code; i.e. less than " +
                                 HTTP_ERROR_THRESHOLD)
             }
         }
@@ -45,10 +45,10 @@ abstract class BindingVerifier {
         fun verifyHttpStatusCodeErrorResponse(code: Int) {
             if (code >= HTTP_ERROR_THRESHOLD) {
                 throw SAMLComplianceException.createWithPropertyMessage(
-                        SAMLBindings_3_5_6_a,
+                        SAMLBindings_3_4_6_a1,
                         property = "HTTP Status Code",
                         actual = code.toString(),
-                        expected = "A non-error http status code, i.e. less than " +
+                        expected = "a non-error http status code; i.e. less than " +
                                 HTTP_ERROR_THRESHOLD +
                                 "\n$IDP_ERROR_RESPONSE_REMINDER_MESSAGE")
             }

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostLoginTest.kt
@@ -134,7 +134,9 @@ class PostLoginTest : StringSpec() {
         }
 
         "POST AuthnRequest With Relay State Greater Than 80 Bytes Test" {
-            Log.debugWithSupplier { "POST AuthnRequest With Relay State Greater Than 80 Bytes Test" }
+            Log.debugWithSupplier {
+                "POST AuthnRequest With Relay State Greater Than 80 Bytes Test"
+            }
             val encodedRequest = Encoder.encodePostMessage(
                     createValidAuthnRequest(), TestCommon.RELAY_STATE_GREATER_THAN_80_BYTES)
             val response = given()
@@ -179,7 +181,10 @@ class PostLoginTest : StringSpec() {
             val authnRequestString = authnRequestToString(authnRequest)
             Log.debugWithSupplier { authnRequestString.prettyPrintXml() }
 
-            val encodedRequest = Encoder.encodePostMessage(authnRequestString, EXAMPLE_RELAY_STATE)
+            val encodedRequest = Encoder.encodePostMessage(
+                    authnRequestString,
+                    EXAMPLE_RELAY_STATE)
+
             val response = given()
                     .urlEncodingEnabled(false)
                     .body(encodedRequest)

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
@@ -183,7 +183,7 @@ class RedirectLoginTest : StringSpec() {
             val response = given()
                     .urlEncodingEnabled(false)
                     .param(SAML_REQUEST, queryParams[SAML_REQUEST]
-                            // using !! here because null is already checked with elvis operator
+                            // using !! here because null is already checked with safe call
                             ?.substring(0, queryParams[SAML_REQUEST]!!.length / 2))
                     .param(SIG_ALG, queryParams[SIG_ALG])
                     .param(SIGNATURE, queryParams[SIGNATURE])

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectLoginTest.kt
@@ -78,8 +78,10 @@ class RedirectLoginTest : StringSpec() {
 
         "Redirect AuthnRequest Test" {
             Log.debugWithSupplier { "Redirect AuthnRequest Test" }
-            val queryParams = SimpleSign()
-                    .signUriString(SAML_REQUEST, createValidAuthnRequest(), null)
+            val queryParams = SimpleSign().signUriString(
+                    SAML_REQUEST,
+                    createValidAuthnRequest(),
+                    null)
 
             // Get response from AuthnRequest
             val response = given()
@@ -105,8 +107,9 @@ class RedirectLoginTest : StringSpec() {
 
         "Redirect AuthnRequest With Relay State Test" {
             Log.debugWithSupplier { "Redirect AuthnRequest With Relay State Test" }
-            val queryParams = SimpleSign()
-                    .signUriString(SAML_REQUEST, createValidAuthnRequest(), TestCommon.EXAMPLE_RELAY_STATE)
+            val queryParams = SimpleSign().signUriString(
+                    SAML_REQUEST, createValidAuthnRequest(),
+                    TestCommon.EXAMPLE_RELAY_STATE)
 
             // Get response from AuthnRequest
             val response = given()
@@ -136,10 +139,13 @@ class RedirectLoginTest : StringSpec() {
         }
 
         "Redirect AuthnRequest With Relay State Greater Than 80 Bytes Test" {
-            Log.debugWithSupplier { "Redirect AuthnRequest With Relay State Greater Than 80 Bytes Test" }
-            val queryParams = SimpleSign()
-                    .signUriString(SAML_REQUEST, createValidAuthnRequest(),
-                            TestCommon.RELAY_STATE_GREATER_THAN_80_BYTES)
+            Log.debugWithSupplier {
+                "Redirect AuthnRequest With Relay State Greater Than 80 Bytes Test"
+            }
+            val queryParams = SimpleSign().signUriString(
+                    SAML_REQUEST,
+                    createValidAuthnRequest(),
+                    TestCommon.RELAY_STATE_GREATER_THAN_80_BYTES)
 
             // Get response from AuthnRequest
             val response = given()
@@ -159,7 +165,42 @@ class RedirectLoginTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            CoreVerifier(responseDom).verifyErrorStatusCode(SAMLBindings_3_4_3_a1, TestCommon.REQUESTER)
+            CoreVerifier(responseDom).verifyErrorStatusCode(
+                    samlErrorCode = SAMLBindings_3_4_3_a1,
+                    expectedStatusCode = TestCommon.REQUESTER)
+        }.config(enabled = false)
+
+        "Redirect Incomplete AuthnRequest In URL Query Test" {
+            Log.debugWithSupplier {
+                "Redirect Incomplete AuthnRequest In URL Query Test"
+            }
+            val queryParams = SimpleSign().signUriString(
+                    SAML_REQUEST,
+                    createValidAuthnRequest(),
+                    null)
+
+            // Get response from AuthnRequest
+            val response = given()
+                    .urlEncodingEnabled(false)
+                    .param(SAML_REQUEST, queryParams[SAML_REQUEST]
+                            // using !! here because null is already checked with elvis operator
+                            ?.substring(0, queryParams[SAML_REQUEST]!!.length / 2))
+                    .param(SIG_ALG, queryParams[SIG_ALG])
+                    .param(SIGNATURE, queryParams[SIGNATURE])
+                    .log()
+                    .ifValidationFails()
+                    .`when`()
+                    .get(Common.getSingleSignOnLocation(REDIRECT_BINDING))
+
+            val idpResponse = TestCommon.parseErrorResponse(response)
+
+            idpResponse.bindingVerifier().verifyError()
+
+            val responseDom = idpResponse.responseDom
+
+            CoreVerifier(responseDom).verifyErrorStatusCode(
+                    SAMLBindings_3_4_3_a1,
+                    TestCommon.REQUESTER)
         }.config(enabled = false)
 
         "Redirect AuthnRequest Without ACS Url Test" {
@@ -181,7 +222,10 @@ class RedirectLoginTest : StringSpec() {
             Log.debugWithSupplier { authnRequestString.prettyPrintXml() }
 
             val encodedRequest = Encoder.encodeRedirectMessage(authnRequestString)
-            val queryParams = SimpleSign().signUriString(SAML_REQUEST, encodedRequest, null)
+            val queryParams = SimpleSign().signUriString(
+                    SAML_REQUEST,
+                    encodedRequest,
+                    null)
 
             // Get response from AuthnRequest
             val response = given()

--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -173,6 +173,7 @@ object SAMLBindings_3_4_5_2_a1 : SAMLBindingRefMessage()
 // todo object SAMLBindings_3_4_5_2_a2 : SAMLBindingRefMessage()
 
 object SAMLBindings_3_4_6_a : SAMLBindingRefMessage()
+object SAMLBindings_3_4_6_a1 : SAMLBindingRefMessage()
 object SAMLBindings_3_5_3_a : SAMLBindingRefMessage()
 object SAMLBindings_3_5_3_b : SAMLBindingRefMessage()
 object SAMLBindings_3_5_4_a : SAMLBindingRefMessage()

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -344,6 +344,9 @@ SAMLBindings_3_4_6_a=HTTP interactions during the message exchange MUST NOT use 
   codes to indicate failures in SAML processing, since the user agent is not a full party to the \
   SAML protocol exchange.
 
+SAMLBindings_3_4_6_a1=[See also SAMLBindings_3_5_6] HTTP interactions during the message exchange \
+  MUST NOT use HTTP error status codes to indicate failures in SAML processing
+
 SAMLBindings_3_5_3_a=The [RelayState] value MUST NOT exceed 80 bytes in length
 
 SAMLBindings_3_5_3_b=If a SAML request message is accompanied by RelayState data, then the SAML \

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -391,10 +391,6 @@ SAMLBindings_3_5_5_2_a=If the message is signed, the Destination XML attribute i
   element of the protocol message MUST contain the URL to which the sender has instructed the user \
   agent to deliver the message.
 
-SAMLBindings_3_5_6_a=HTTP interactions during the message exchange MUST NOT use HTTP error status \
-  codes to indicate failures in SAML processing, since the user agent is not a full party to the \
-  SAML protocol exchange.
-
 #------------------
 # XML Datatype Schema
 #------------------


### PR DESCRIPTION
Adds negative test for incomplete SAMLRequest query argument. Also formats the login tests a little bit (line length).