### PR TITLE
Profiles: Added a negative path test

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -41,13 +41,14 @@ class TestCommon {
         const val EXAMPLE_RELAY_STATE = "relay+State"
         const val RELAY_STATE_GREATER_THAN_80_BYTES = "RelayStateLongerThan80CharsIsIncorrect" +
                 "AccordingToTheSamlSpecItMustNotExceed80BytesInLength"
-        const val MAX_RELAYSTATE_LEN = 80
+        const val MAX_RELAY_STATE_LEN = 80
+        const val INCORRECT_ACS_URL = "https://incorrect.acs.url"
         const val INCORRECT_DESTINATION = "https://incorrect.destination.com"
 
         const val IDP_ERROR_RESPONSE_REMINDER_MESSAGE = "Make sure the IdP responds immediately " +
                 "with a SAML error response (See section 3.2.1 in the SAML Core specification)"
         const val REQUESTER = "urn:oasis:names:tc:SAML:2.0:status:Requester"
-        const val VERSION_MISMATCH = "urn:oasis:names:tc:SAML:2.0:status:VersionMismatch"
+        private const val VERSION_MISMATCH = "urn:oasis:names:tc:SAML:2.0:status:VersionMismatch"
         private const val SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success"
         private const val RESPONDER = "urn:oasis:names:tc:SAML:2.0:status:Responder"
         val TOP_LEVEL_STATUS_CODES = setOf(SUCCESS, REQUESTER, RESPONDER, VERSION_MISMATCH)
@@ -112,7 +113,7 @@ class TestCommon {
          * processing.
          *
          * @param response The error response returned from the first interaction with the IdP under
-          * test.
+         * test.
          * @return An {@code IdpResponse} object created from the error response.
          */
         fun parseErrorResponse(response: Response): IdpResponseDecorator {

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
@@ -34,7 +34,7 @@ import org.codice.compliance.debugWithSupplier
 import org.codice.compliance.prettyPrintXml
 import org.codice.compliance.utils.TestCommon.Companion.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.TestCommon.Companion.IDP_ERROR_RESPONSE_REMINDER_MESSAGE
-import org.codice.compliance.utils.TestCommon.Companion.MAX_RELAYSTATE_LEN
+import org.codice.compliance.utils.TestCommon.Companion.MAX_RELAY_STATE_LEN
 import org.codice.compliance.utils.TestCommon.Companion.acsUrl
 import org.codice.compliance.utils.decorators.IdpPostResponseDecorator
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
@@ -212,7 +212,7 @@ class PostBindingVerifier(private val response: IdpPostResponseDecorator) : Bind
         val relayState = response.relayState
         val isRelayStateGiven = response.isRelayStateGiven
 
-        if (relayState.toByteArray().size > MAX_RELAYSTATE_LEN)
+        if (relayState.toByteArray().size > MAX_RELAY_STATE_LEN)
             throw SAMLComplianceException.createWithPropertyMessage(SAMLBindings_3_5_3_a,
                     property = RELAY_STATE,
                     actual = relayState)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
@@ -40,7 +40,7 @@ import org.codice.compliance.debugWithSupplier
 import org.codice.compliance.prettyPrintXml
 import org.codice.compliance.utils.TestCommon.Companion.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.TestCommon.Companion.IDP_ERROR_RESPONSE_REMINDER_MESSAGE
-import org.codice.compliance.utils.TestCommon.Companion.MAX_RELAYSTATE_LEN
+import org.codice.compliance.utils.TestCommon.Companion.MAX_RELAY_STATE_LEN
 import org.codice.compliance.utils.TestCommon.Companion.acsUrl
 import org.codice.compliance.utils.TestCommon.Companion.idpMetadata
 import org.codice.compliance.utils.decorators.IdpRedirectResponseDecorator
@@ -391,7 +391,7 @@ class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator
                     cause = e)
         }
 
-        if (decodedRelayState.toByteArray().size > MAX_RELAYSTATE_LEN) {
+        if (decodedRelayState.toByteArray().size > MAX_RELAY_STATE_LEN) {
             throw SAMLComplianceException.create(SAMLBindings_3_4_3_a,
                     message = "RelayState value of $decodedRelayState was longer than 80 bytes.")
         }


### PR DESCRIPTION
- Added a test for:
```
Note that if the <AuthnRequest> is not authenticated and/or integrity protected, 
the information in it MUST NOT be trusted except as advisory. Whether the request 
is signed or not, the identity provider MUST ensure that any 
<AssertionConsumerServiceURL> or <AssertionConsumerServiceIndex> elements 
in the request are verified as belonging to the service provider to whom the response 
will be sent.
```
The test is ignored because DDF returns the login page. It doesn't check after logging in too.
- Added the last two profiles Post tests for the Redirect binding tests
- Moved all negative path tests at the bottom of the test classes