### PR TITLE
Refactored SamlAssertionsVerifier

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
@@ -35,11 +35,7 @@ const val FOUR_DIGIT_YEAR_LEN = 4
 
 var ids = mutableListOf<String>()
 
-/**
- * Verify common data types against the core specification
- *
- * 1.3 Common Data Types
- */
+/** 1.3 Common Data Types **/
 fun verifyCommonDataType(samlDom: Node) {
     ids = mutableListOf()
     var i = samlDom.childNodes.length - 1
@@ -62,11 +58,7 @@ fun verifyCommonDataType(samlDom: Node) {
     }
 }
 
-/**
- * Verify values of type string
- *
- * 1.3.1 String Values
- */
+/** 1.3.1 String Values **/
 fun verifyStringValues(node: Node, errorCode: SAMLSpecRefMessage?) {
     if (StringUtils.isBlank(node.textContent)) {
         if (errorCode != null) throw SAMLComplianceException.create(errorCode, SAMLCore_1_3_1_a,
@@ -76,11 +68,7 @@ fun verifyStringValues(node: Node, errorCode: SAMLSpecRefMessage?) {
     }
 }
 
-/**
- * Verify values of type anyURI
- *
- * 1.3.2 URI Values
- */
+/** 1.3.2 URI Values **/
 fun verifyUriValues(node: Node, errorCode: SAMLSpecRefMessage?) {
     // todo - make sure uri absolute check is correct
     if (StringUtils.isBlank(node.textContent)
@@ -92,11 +80,7 @@ fun verifyUriValues(node: Node, errorCode: SAMLSpecRefMessage?) {
     }
 }
 
-/**
- * Verify values of type ID
- *
- * 1.3.4 ID and ID Reference Values
- */
+/** 1.3.4 ID and ID Reference Values **/
 fun verifyIdValues(node: Node, errorCode: SAMLSpecRefMessage?) {
     if (ids.contains(node.textContent)) {
         if (errorCode != null) throw SAMLComplianceException.create(errorCode, SAMLCore_1_3_4,
@@ -106,11 +90,7 @@ fun verifyIdValues(node: Node, errorCode: SAMLSpecRefMessage?) {
     } else ids.add(node.textContent)
 }
 
-/**
- * Verify values of type dateTime
- *
- * 1.3.3 Time Values
- */
+/** 1.3.3 Time Values **/
 fun verifyTimeValues(node: Node, errorCode: SAMLSpecRefMessage?) {
     val dateTime = node.textContent
     val (year, restOfDateTime) = splitByYear(dateTime, errorCode)
@@ -150,6 +130,7 @@ private fun splitByYear(dateTime: String, errorCode: SAMLSpecRefMessage?): Split
     return SplitString(dateTime.substring(0, hyphenIndex), dateTime.substring(hyphenIndex + 1))
 }
 
+// https://www.w3.org/TR/xmlschema-2/#dateTime
 @Suppress("SpreadOperator" /* Judicious use of spread operator to reduce cognitive complexity */)
 private fun verifyYear(year: String, errorCode: SAMLSpecRefMessage?) {
     // remove the negative sign to make verification easier
@@ -158,8 +139,7 @@ private fun verifyYear(year: String, errorCode: SAMLSpecRefMessage?) {
     val codes = if (errorCode == null) emptyArray()
     else arrayOf(errorCode)
 
-    // check if year is an integer && https://www.w3.org/TR/xmlschema-2/#dateTime "a plus sign is
-    // not permitted"
+    // check if year is an integer && "a plus sign is not permitted"
     if (!strippedYear.matches("""\d+""".toRegex())) {
         throw SAMLComplianceException.create(*codes,
                 SAMLCore_1_3_3,
@@ -167,8 +147,7 @@ private fun verifyYear(year: String, errorCode: SAMLSpecRefMessage?) {
                 message = "A '+' was found.")
     }
 
-    // https://www.w3.org/TR/xmlschema-2/#dateTime "if more than four digits, leading zeros are
-    // prohibited"
+    // "if more than four digits, leading zeros are prohibited"
     if (strippedYear.length > FOUR_DIGIT_YEAR_LEN && strippedYear.startsWith('0')) {
         throw SAMLComplianceException.create(*codes,
                 SAMLCore_1_3_3,
@@ -176,7 +155,7 @@ private fun verifyYear(year: String, errorCode: SAMLSpecRefMessage?) {
                 message = "The year value of $strippedYear is invalid.")
     }
 
-    // https://www.w3.org/TR/xmlschema-2/#dateTime "'0000' is prohibited"
+    // "'0000' is prohibited"
     if (strippedYear == "0000") {
         throw SAMLComplianceException.create(*codes,
                 SAMLCore_1_3_3,

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -68,10 +68,7 @@ class CoreVerifier(val node: Node) {
      */
     fun verify() {
         verifyCommonDataType(node)
-
-        val samlAssertionsVerifier = SamlAssertionsVerifier(node)
-        samlAssertionsVerifier.verify()
-
+        SamlAssertionsVerifier(node).verify()
         verifySignatureSyntaxAndProcessing(node)
         verifyGeneralConsiderations(node)
     }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlAssertionsVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlAssertionsVerifier.kt
@@ -13,59 +13,38 @@
  */
 package org.codice.compliance.verification.core
 
-import org.apache.commons.lang3.StringUtils
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLCore_2_2_3_a
-import org.codice.compliance.SAMLCore_2_2_3_b
 import org.codice.compliance.SAMLCore_2_2_4_a
-import org.codice.compliance.SAMLCore_2_3_3_a
-import org.codice.compliance.SAMLCore_2_3_3_b
-import org.codice.compliance.SAMLCore_2_3_3_c
-import org.codice.compliance.SAMLCore_2_3_4_a
-import org.codice.compliance.SAMLCore_2_4_1_3
-import org.codice.compliance.SAMLCore_2_5_1_2
-import org.codice.compliance.SAMLCore_2_5_1_5
-import org.codice.compliance.SAMLCore_2_5_1_6_a
-import org.codice.compliance.SAMLCore_2_5_1_6_b
-import org.codice.compliance.SAMLCore_2_5_1_a
-import org.codice.compliance.SAMLCore_2_5_1_b
-import org.codice.compliance.SAMLCore_2_5_1_c
-import org.codice.compliance.SAMLCore_2_7_2
-import org.codice.compliance.SAMLCore_2_7_3
-import org.codice.compliance.SAMLCore_2_7_3_1_1
-import org.codice.compliance.SAMLCore_2_7_3_2_a
-import org.codice.compliance.SAMLCore_2_7_4
-import org.codice.compliance.XMLSignature_4_5
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.ELEMENT
-import org.codice.compliance.utils.TestCommon.Companion.XSI
+import org.codice.compliance.verification.core.internal.AssertionsVerifier
+import org.codice.compliance.verification.core.internal.ConditionsVerifier
+import org.codice.compliance.verification.core.internal.StatementVerifier
+import org.codice.compliance.verification.core.internal.SubjectVerifier
 import org.w3c.dom.Node
-import java.time.Instant
 
-@Suppress("StringLiteralDuplication", "LargeClass", "TooManyFunctions"
-/* Core assertion verification is a complex, but single responsibility issue. */)
+@Suppress("StringLiteralDuplication")
 class SamlAssertionsVerifier(val node: Node) {
     /**
      * Verify assertions against the Core Spec document
      * 2 SAML Assertions
      */
     fun verify() {
-        verifyEncryptedId()
-        verifyCoreAssertion()
-        verifyEncryptedAssertion()
-        verifySubjectElements()
-        verifyConditions()
-        verifyAuthnStatementAndAttributeStatement()
-        verifyAttributeElements()
-        verifyAuthzDecisionStatementAndAction()
+        verifyNameIdentifiers()
+        AssertionsVerifier(node).verify()
+        SubjectVerifier(node).verify()
+        ConditionsVerifier(node).verify()
+        StatementVerifier(node).verify()
     }
 
     /**
-     * Verify the <EncryptedId> Element against the Core Spec document
+     * Verify the Name Identifiers against the Core Spec document
+     * 2.2 Name Identifiers
      * 2.2.4 Element <EncryptedID>
      */
-    private fun verifyEncryptedId() {
+    private fun verifyNameIdentifiers() {
+        // EncryptedID
         node.allChildren("EncryptedID").forEach {
             val encryptedData = it.children("EncryptedData")
             if (encryptedData.isEmpty()) throw SAMLComplianceException
@@ -73,8 +52,7 @@ class SamlAssertionsVerifier(val node: Node) {
                             "EncryptedData",
                             "EncryptedId")
 
-            if (encryptedData
-                            .filter { it.attributes.getNamedItem("Type") != null }
+            if (encryptedData.filter { it.attributes.getNamedItem("Type") != null }
                             .any { it.attributes.getNamedItem("Type").textContent != ELEMENT })
                 throw SAMLComplianceException.create(SAMLCore_2_2_4_a,
                         message = "Type attribute found with an incorrect value.",
@@ -86,374 +64,5 @@ class SamlAssertionsVerifier(val node: Node) {
         // todo - Encrypted identifiers are intended as a privacy protection mechanism when the
         // plain-text value passes through an intermediary. As such, the ciphertext MUST be unique
         // to any given encryption operation. For more on such issues, see [XMLEnc] Section 6.3.
-    }
-
-    /**
-     * Verify the <Assertion> Element against the Core Spec document
-     * 2.3.3 Element <Assertion>
-     */
-    @Suppress("ComplexCondition")
-    private fun verifyCoreAssertion() {
-        node.allChildren("Assertion").forEach {
-            if (it.attributes.getNamedItem("Version")?.textContent == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
-                        "Version",
-                        "Assertion",
-                        node = node)
-            if (it.attributes.getNamedItem("Version").textContent != "2.0")
-                throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_3_3_a,
-                        property = "Version",
-                        actual = it.attributes.getNamedItem("Version").textContent,
-                        expected = "2.0",
-                        node = node)
-
-            if (it.attributes.getNamedItem("ID") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
-                        "ID",
-                        "Assertion",
-                        node = node)
-            verifyIdValues(it.attributes.getNamedItem("ID"), SAMLCore_2_3_3_b)
-
-            if (it.attributes.getNamedItem("IssueInstant") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
-                        "IssueInstant",
-                        "Assertion",
-                        node = node)
-            verifyTimeValues(it.attributes.getNamedItem("IssueInstant"), SAMLCore_2_3_3_c)
-
-            if (it.children("Issuer").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
-                        "Issuer",
-                        "Assertion",
-                        node = node)
-
-            val statements = it.children("Statement")
-            if (statements.any { it.attributes.getNamedItemNS(XSI, "type") == null })
-                throw SAMLComplianceException.create(SAMLCore_2_2_3_a,
-                        message = "Statement element found without a type.",
-                        node = node)
-
-            if (statements.isEmpty()
-                    && it.children("AuthnStatement").isEmpty()
-                    && it.children("AuthzDecisionStatement").isEmpty()
-                    && it.children("AttributeStatement").isEmpty()
-                    && it.children("Subject").isEmpty())
-                throw SAMLComplianceException.create(SAMLCore_2_2_3_b,
-                        message = "No Subject or Statement elements found.",
-                        node = node)
-        }
-    }
-
-    /**
-     * Verify the <EncryptedAssertion> element against the Core Spec document
-     * 2.3.4 Element <EncryptedAssertion>
-     */
-    private fun verifyEncryptedAssertion() {
-        node.allChildren("EncryptedAssertion").forEach {
-            val encryptedData = it.children("EncryptedData")
-            if (encryptedData.isEmpty())
-                throw SAMLComplianceException
-                        .createWithXmlPropertyReqMessage("SAMLCore.2.3.4",
-                                "EncryptedData",
-                                "EncryptedAssertion",
-                                node = node)
-
-            if (encryptedData
-                            .filter { it.attributes.getNamedItem("Type") != null }
-                            .any { it.attributes.getNamedItem("Type").textContent != ELEMENT })
-                throw SAMLComplianceException.create(SAMLCore_2_3_4_a,
-                        message = "Type attribute found with an incorrect value.",
-                        node = node)
-            // todo - The encrypted content MUST contain an element that has a type of or derived
-            // from AssertionType.
-        }
-    }
-
-    /**
-     * Verify subject elements against the Core Spec
-     * 2.4.1.1 Element <SubjectConfirmation>
-     * 2.4.1.2 Element <SubjectConfirmationData>
-     * 2.4.1.3 Complex Type KeyInfoConfirmationDataType
-     */
-    private fun verifySubjectElements() {
-        // SubjectConfirmation
-        if (node.allChildren("SubjectConfirmation")
-                        .any { it.attributes.getNamedItem("Method") == null })
-            throw SAMLComplianceException
-                    .createWithXmlPropertyReqMessage("SAMLCore.2.4.1.1",
-                            "Method",
-                            "SubjectConfirmation",
-                            node = node)
-
-        // SubjectConfirmationData
-        node.allChildren("SubjectConfirmationData").forEach {
-            // todo - SAML extensions MUST NOT add local (non-namespace-qualified) XML attributes or
-            // XML attributes qualified by a SAML-defined namespace to the
-            // SubjectConfirmationDataType complex type or a derivation of it; such attributes are
-            // reserved for future maintenance and enhancement of SAML itself.
-
-            val notBefore = it.attributes.getNamedItem("NotBefore")
-            val notOnOrAfter = it.attributes.getNamedItem("NotOnOrAfter")
-            if (notBefore != null
-                    && notOnOrAfter != null) {
-                val notBeforeValue = Instant.parse(notBefore.textContent)
-                val notOnOrAfterValue = Instant.parse(notOnOrAfter.textContent)
-                if (notBeforeValue.isAfter(notOnOrAfterValue))
-                    throw SAMLComplianceException.create(SAMLCore_2_5_1_2,
-                        message = "NotBefore element with value $notBeforeValue is not less than " +
-                                "NotOnOrAfter element with value $notOnOrAfterValue.",
-                        node = node)
-            }
-
-            // KeyInfoConfirmationDataType
-            if (it.attributes
-                            ?.getNamedItemNS(XSI, "type")
-                            ?.textContent?.contains("KeyInfoConfirmationDataType") == true
-                    && it.children("KeyInfo").any { it.children("KeyValue").size > 1 })
-                throw SAMLComplianceException.create(SAMLCore_2_4_1_3, XMLSignature_4_5,
-                        message = "Multiple Keys found within the KeyInfo element.",
-                        node = node)
-        }
-    }
-
-    /**
-     * Verify the <Conditions> element against the Core Spec
-     * 2.5.1 Element <Conditions>
-     * 2.5.1.2 Attributes NotBefore and NotOnOrAfter
-     * 2.5.1.5 Element <OneTimeUse>
-     * 2.5.1.6 Element <ProxyRestriction>
-     */
-    private fun verifyConditions() {
-        node.allChildren("Conditions").forEach {
-            val conditionsElement = it
-
-            verifyConditionType(conditionsElement)
-
-            verifyOneTimeUse(conditionsElement)
-
-            verifyProxyRestrictions(conditionsElement)
-
-            val notBefore = it.attributes.getNamedItem("NotBefore")
-            val notOnOrAfter = it.attributes.getNamedItem("NotOnOrAfter")
-            if (notBefore != null
-                    && notOnOrAfter != null) {
-                val notBeforeValue = Instant.parse(notBefore.textContent)
-                val notOnOrAfterValue = Instant.parse(notOnOrAfter.textContent)
-                if (notBeforeValue.isAfter(notOnOrAfterValue))
-                    throw SAMLComplianceException.create(SAMLCore_2_5_1_2,
-                        message = "NotBefore element with value $notBeforeValue is not less than " +
-                                "NotOnOrAfter element with value $notOnOrAfterValue.",
-                        node = node)
-            }
-        }
-    }
-
-    private fun verifyProxyRestrictions(conditionsElement: Node) {
-        val proxyRestrictions = conditionsElement.children("ProxyRestriction")
-        if (!proxyRestrictions.isNotEmpty()) return
-
-        if (proxyRestrictions.size > 1)
-            throw SAMLComplianceException.create(SAMLCore_2_5_1_c, SAMLCore_2_5_1_6_b,
-                    message = "Cannot have more than one ProxyRestriction element.",
-                    node = node)
-
-        val proxyRestrictionAudiences = proxyRestrictions
-                .flatMap { it.children("Audience") }
-                .map { it.textContent }
-                .toList()
-
-        if (!proxyRestrictionAudiences.isNotEmpty()) return
-
-        val audienceRestrictions = conditionsElement.allChildren("AudienceRestriction")
-
-        if (audienceRestrictions.isEmpty()) throw SAMLComplianceException.create(SAMLCore_2_5_1_6_a,
-                message = "There must be an AudienceRestriction element.",
-                node = node)
-
-        audienceRestrictions.forEach {
-            val audienceRestrictionAudiences = it.children("Audience")
-            if (audienceRestrictionAudiences.isEmpty())
-                throw SAMLComplianceException.create(SAMLCore_2_5_1_6_a,
-                        message = "The AudienceRestriction element must contain at least one " +
-                                "Audience element.",
-                        node = node)
-            it.children("Audience").forEach {
-                if (!proxyRestrictionAudiences.contains(it.textContent))
-                    throw SAMLComplianceException.create(SAMLCore_2_5_1_6_a,
-                            message = "The AudienceRestriction can only have Audience elements " +
-                                    "that are also in the ProxyRestriction element.",
-                            node = node)
-            }
-        }
-    }
-
-    private fun verifyOneTimeUse(conditionsElement: Node) {
-        if (conditionsElement.children("OneTimeUse").size > 1)
-            throw SAMLComplianceException.create(SAMLCore_2_5_1_b, SAMLCore_2_5_1_5,
-                    message = "Cannot have more than one OneTimeUse element.",
-                    node = node)
-    }
-
-    private fun verifyConditionType(conditionsElement: Node) {
-        if (conditionsElement.children("Condition")
-                        .any { it.attributes.getNamedItemNS(XSI, "type") == null })
-            throw SAMLComplianceException.create(SAMLCore_2_5_1_a,
-                    message = "Condition found without a type.",
-                    node = node)
-    }
-
-    /**
-     * Verify the <AuthnStatement> element against the Core Spec
-     * 2.7.2 Element <AuthnStatement>
-     */
-    private fun verifyAuthnStatementAndAttributeStatement() {
-        if (node.allChildren("Assertion")
-                        .filter { it.children("AuthnStatement").isNotEmpty() }
-                        .any { it.children("Subject").isEmpty() })
-            throw SAMLComplianceException.create(SAMLCore_2_7_2,
-                    message = "An AuthnStatement was found without a Subject element.",
-                    node = node)
-
-        node.allChildren("AuthnStatement").forEach {
-            if (it.attributes.getNamedItem("AuthnInstant") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.2",
-                        "AuthnInstant",
-                        "AuthnStatement",
-                        node = node)
-
-            if (it.children("AuthnContext").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.2",
-                        "AuthnContext",
-                        "AuthnStatement",
-                        node = node)
-        }
-    }
-
-    /**
-     * Verify the <AttributeStatement> and <Attribute> elements against the Core Spec
-     * 2.7.3 Element <AttributeStatement>
-     * 2.7.3.1 Element <Attribute>
-     * 2.7.3.2 Element <EncryptedAttribute>
-     */
-    private fun verifyAttributeElements() {
-        verifyAttributeStatement()
-        verifyAttribute()
-        verifyEncryptedAttribute()
-    }
-
-    private fun verifyEncryptedAttribute() {
-        node.allChildren("EncryptedAttribute").forEach {
-            val encryptedData = it.children("EncryptedData")
-            if (encryptedData.isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.3.2",
-                        "EncryptedData",
-                        "EncryptedAttribute",
-                        node = node)
-
-            if (encryptedData
-                            .filter { it.attributes.getNamedItem("Type") != null }
-                            .any { it.attributes.getNamedItem("Type").textContent != ELEMENT })
-                throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_7_3_2_a,
-                        property = "Type",
-                        actual = it.attributes.getNamedItem("Type").textContent,
-                        expected = ELEMENT,
-                        node = node)
-            // todo - The encrypted content MUST contain an element that has a type of or derived
-            // from AssertionType.
-        }
-    }
-
-    @Suppress("ComplexCondition")
-    private fun verifyAttribute() {
-        node.allChildren("Attribute").forEach {
-            if (it.attributes.getNamedItem("Name") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.3.1",
-                        "Name",
-                        "Attribute",
-                        node = node)
-
-            val nameAttribute = it.attributes.getNamedItem("Name")
-            val nameFormatAttribute = it.attributes.getNamedItem("NameFormat")
-            val friendlyNameAttr = it.attributes.getNamedItem("FriendlyName")
-
-            if ((nameAttribute != null && nameAttribute.textContent == null)
-                    || (nameFormatAttribute != null && nameFormatAttribute.textContent == null)
-                    || (friendlyNameAttr != null && friendlyNameAttr.textContent == null)) {
-                verifyAttributeValue(it)
-            }
-        }
-    }
-
-    private fun verifyAttributeValue(it: Node) {
-        it.children("AttributeValue").forEach {
-            val nilAttribute = it.attributes.getNamedItemNS(XSI, "nil")?.textContent
-            if (StringUtils.isNotBlank(it.textContent) ||
-                    (nilAttribute != "true" && nilAttribute != "1"))
-                throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_7_3_1_1,
-                        property = "xsi:nil XML attribute",
-                        actual = nilAttribute,
-                        node = node)
-        }
-    }
-
-    private fun verifyAttributeStatement() {
-        if (node.allChildren("Assertion")
-                        .filter { it.children("AttributeStatement").isNotEmpty() }
-                        .any { it.children("Subject").isEmpty() })
-            throw SAMLComplianceException.create(SAMLCore_2_7_3,
-                    message = "An AttributeStatement was found without a Subject element.",
-                    node = node)
-
-        node.allChildren("AttributeStatement").forEach {
-            if (it.children("Attribute").isEmpty() && it.children("EncryptedAttribute").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.3",
-                        "Attribute or EncryptedAttribute",
-                        "AttributeStatement",
-                        node = node)
-        }
-    }
-
-    /**
-     * Verify the <AuthzDecisionStatement> and <Action> elements against the Core Spec
-     * 2.7.4 Element <AuthzDecisionStatement>
-     * 2.7.4.2 Element <Action>
-     */
-    private fun verifyAuthzDecisionStatementAndAction() {
-        // AuthzDecisionStatement
-        node.allChildren("Assertion").forEach {
-            if (it.children("AuthzDecisionStatement").isNotEmpty()
-                    && it.children("Subject").isEmpty())
-                throw SAMLComplianceException.create(SAMLCore_2_7_4,
-                        message = "No Subject element found.",
-                        node = node)
-        }
-
-        node.allChildren("AuthzDecisionStatement").forEach {
-            if (it.attributes.getNamedItem("Resource") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4",
-                        "Resource",
-                        "AuthzDecisionStatement",
-                        node = node)
-            if (it.attributes.getNamedItem("Decision") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4",
-                        "Decision",
-                        "AuthzDecisionStatement",
-                        node = node)
-            if (it.children("Action").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4",
-                        "Action",
-                        "AuthzDecisionStatement",
-                        node = node)
-        }
-
-        // Action
-        val actions = node.allChildren("Action")
-        actions.forEach {
-            if (it.attributes.getNamedItem("Namespace") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4.2",
-                        "Namespace",
-                        "Action",
-                        node = node)
-        }
     }
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/AssertionsVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/AssertionsVerifier.kt
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.internal
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLCore_2_2_3_a
+import org.codice.compliance.SAMLCore_2_2_3_b
+import org.codice.compliance.SAMLCore_2_3_3_a
+import org.codice.compliance.SAMLCore_2_3_3_b
+import org.codice.compliance.SAMLCore_2_3_3_c
+import org.codice.compliance.SAMLCore_2_3_4_a
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.utils.TestCommon
+import org.codice.compliance.verification.core.verifyIdValues
+import org.codice.compliance.verification.core.verifyTimeValues
+import org.w3c.dom.Node
+
+@Suppress("StringLiteralDuplication")
+internal class AssertionsVerifier(val node: Node) {
+
+    fun verify() {
+        verifyCoreAssertion()
+        verifyEncryptedAssertion()
+    }
+
+    /**
+     * Verify the <Assertion> Element against the Core Spec document
+     * 2.3.3 Element <Assertion>
+     */
+    @Suppress("ComplexCondition")
+    private fun verifyCoreAssertion() {
+        node.allChildren("Assertion").forEach {
+            if (it.attributes.getNamedItem("Version")?.textContent == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
+                        "Version",
+                        "Assertion",
+                        node = node)
+            if (it.attributes.getNamedItem("Version").textContent != "2.0")
+                throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_3_3_a,
+                        property = "Version",
+                        actual = it.attributes.getNamedItem("Version").textContent,
+                        expected = "2.0",
+                        node = node)
+
+            if (it.attributes.getNamedItem("ID") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
+                        "ID",
+                        "Assertion",
+                        node = node)
+            verifyIdValues(it.attributes.getNamedItem("ID"), SAMLCore_2_3_3_b)
+
+            if (it.attributes.getNamedItem("IssueInstant") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
+                        "IssueInstant",
+                        "Assertion",
+                        node = node)
+            verifyTimeValues(it.attributes.getNamedItem("IssueInstant"), SAMLCore_2_3_3_c)
+
+            if (it.children("Issuer").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.3.3",
+                        "Issuer",
+                        "Assertion",
+                        node = node)
+
+            val statements = it.children("Statement")
+            if (statements.any { it.attributes.getNamedItemNS(TestCommon.XSI, "type") == null })
+                throw SAMLComplianceException.create(SAMLCore_2_2_3_a,
+                        message = "Statement element found without a type.",
+                        node = node)
+
+            if (statements.isEmpty()
+                    && it.children("AuthnStatement").isEmpty()
+                    && it.children("AuthzDecisionStatement").isEmpty()
+                    && it.children("AttributeStatement").isEmpty()
+                    && it.children("Subject").isEmpty())
+                throw SAMLComplianceException.create(SAMLCore_2_2_3_b,
+                        message = "No Subject or Statement elements found.",
+                        node = node)
+        }
+    }
+
+    /**
+     * Verify the <EncryptedAssertion> element against the Core Spec document
+     * 2.3.4 Element <EncryptedAssertion>
+     */
+    private fun verifyEncryptedAssertion() {
+        node.allChildren("EncryptedAssertion").forEach {
+            val encryptedData = it.children("EncryptedData")
+            if (encryptedData.isEmpty())
+                throw SAMLComplianceException
+                        .createWithXmlPropertyReqMessage("SAMLCore.2.3.4",
+                                "EncryptedData",
+                                "EncryptedAssertion",
+                                node = node)
+
+            if (encryptedData.filter { it.attributes.getNamedItem("Type") != null }
+                            .any { it.attributes.getNamedItem("Type").textContent !=
+                                    TestCommon.ELEMENT })
+                throw SAMLComplianceException.create(SAMLCore_2_3_4_a,
+                        message = "Type attribute found with an incorrect value.",
+                        node = node)
+            // todo - The encrypted content MUST contain an element that has a type of or derived
+            // from AssertionType.
+        }
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/ConditionsVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/ConditionsVerifier.kt
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.internal
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLCore_2_5_1_2
+import org.codice.compliance.SAMLCore_2_5_1_5
+import org.codice.compliance.SAMLCore_2_5_1_6_a
+import org.codice.compliance.SAMLCore_2_5_1_6_b
+import org.codice.compliance.SAMLCore_2_5_1_a
+import org.codice.compliance.SAMLCore_2_5_1_b
+import org.codice.compliance.SAMLCore_2_5_1_c
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.utils.TestCommon
+import org.w3c.dom.Node
+import java.time.Instant
+
+@Suppress("StringLiteralDuplication")
+internal class ConditionsVerifier(val node: Node) {
+
+    fun verify() {
+        node.allChildren("Conditions").forEach {
+            verifyConditionAttributes(it)
+            verifyConditionType(it)
+            verifyOneTimeUse(it)
+            verifyProxyRestrictions(it)
+        }
+    }
+
+    /**
+     * Verify the <Conditions> element against the Core Spec
+     * 2.5.1 Element <Conditions>
+     * 2.5.1.2 Attributes NotBefore and NotOnOrAfter
+     * 2.5.1.5 Element <OneTimeUse>
+     * 2.5.1.6 Element <ProxyRestriction>
+     */
+    private fun verifyConditionAttributes(conditionsElement: Node) {
+        val notBefore = conditionsElement.attributes.getNamedItem("NotBefore")
+        val notOnOrAfter = conditionsElement.attributes.getNamedItem("NotOnOrAfter")
+        if (notBefore != null
+                && notOnOrAfter != null) {
+            val notBeforeValue = Instant.parse(notBefore.textContent)
+            val notOnOrAfterValue = Instant.parse(notOnOrAfter.textContent)
+            if (notBeforeValue.isAfter(notOnOrAfterValue))
+                throw SAMLComplianceException.create(SAMLCore_2_5_1_2,
+                        message = "NotBefore element with value $notBeforeValue is not less than " +
+                                "NotOnOrAfter element with value $notOnOrAfterValue.",
+                        node = node)
+        }
+    }
+
+    private fun verifyConditionType(conditionsElement: Node) {
+        if (conditionsElement.children("Condition")
+                        .any { it.attributes.getNamedItemNS(TestCommon.XSI, "type") == null })
+            throw SAMLComplianceException.create(SAMLCore_2_5_1_a,
+                    message = "Condition found without a type.",
+                    node = node)
+    }
+
+    private fun verifyOneTimeUse(conditionsElement: Node) {
+        if (conditionsElement.children("OneTimeUse").size > 1)
+            throw SAMLComplianceException.create(SAMLCore_2_5_1_b, SAMLCore_2_5_1_5,
+                    message = "Cannot have more than one OneTimeUse element.",
+                    node = node)
+    }
+
+    private fun verifyProxyRestrictions(conditionsElement: Node) {
+        val proxyRestrictions = conditionsElement.children("ProxyRestriction")
+        if (!proxyRestrictions.isNotEmpty()) return
+
+        if (proxyRestrictions.size > 1)
+            throw SAMLComplianceException.create(SAMLCore_2_5_1_c, SAMLCore_2_5_1_6_b,
+                    message = "Cannot have more than one ProxyRestriction element.",
+                    node = node)
+
+        val proxyRestrictionAudiences = proxyRestrictions
+                .flatMap { it.children("Audience") }
+                .map { it.textContent }
+                .toList()
+
+        if (!proxyRestrictionAudiences.isNotEmpty()) return
+
+        val audienceRestrictions = conditionsElement.allChildren("AudienceRestriction")
+
+        if (audienceRestrictions.isEmpty()) throw SAMLComplianceException.create(SAMLCore_2_5_1_6_a,
+                message = "There must be an AudienceRestriction element.",
+                node = node)
+
+        audienceRestrictions.forEach {
+            val audienceRestrictionAudiences = it.children("Audience")
+            if (audienceRestrictionAudiences.isEmpty())
+                throw SAMLComplianceException.create(SAMLCore_2_5_1_6_a,
+                        message = "The AudienceRestriction element must contain at least one " +
+                                "Audience element.",
+                        node = node)
+            it.children("Audience").forEach {
+                if (!proxyRestrictionAudiences.contains(it.textContent))
+                    throw SAMLComplianceException.create(SAMLCore_2_5_1_6_a,
+                            message = "The AudienceRestriction can only have Audience elements " +
+                                    "that are also in the ProxyRestriction element.",
+                            node = node)
+            }
+        }
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/StatementVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/StatementVerifier.kt
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.internal
+
+import org.apache.commons.lang3.StringUtils
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLCore_2_7_2
+import org.codice.compliance.SAMLCore_2_7_3
+import org.codice.compliance.SAMLCore_2_7_3_1_1
+import org.codice.compliance.SAMLCore_2_7_3_2_a
+import org.codice.compliance.SAMLCore_2_7_4
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.utils.TestCommon
+import org.w3c.dom.Node
+
+@Suppress("StringLiteralDuplication")
+internal class StatementVerifier(val node: Node) {
+
+    fun verify() {
+        verifyAuthnStatementAndAttributeStatement()
+        verifyAttributeStatement()
+        verifyAttribute()
+        verifyEncryptedAttribute()
+        verifyAuthzDecisionStatement()
+        verifyAction()
+    }
+
+    /** 2.7.2 Element <AuthnStatement> **/
+    private fun verifyAuthnStatementAndAttributeStatement() {
+        if (node.allChildren("Assertion")
+                        .filter { it.children("AuthnStatement").isNotEmpty() }
+                        .any { it.children("Subject").isEmpty() })
+            throw SAMLComplianceException.create(SAMLCore_2_7_2,
+                    message = "An AuthnStatement was found without a Subject element.",
+                    node = node)
+
+        node.allChildren("AuthnStatement").forEach {
+            if (it.attributes.getNamedItem("AuthnInstant") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.2",
+                        "AuthnInstant",
+                        "AuthnStatement",
+                        node = node)
+
+            if (it.children("AuthnContext").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.2",
+                        "AuthnContext",
+                        "AuthnStatement",
+                        node = node)
+        }
+    }
+
+    /** 2.7.3.2 Element <EncryptedAttribute> **/
+    private fun verifyEncryptedAttribute() {
+        node.allChildren("EncryptedAttribute").forEach {
+            val encryptedData = it.children("EncryptedData")
+            if (encryptedData.isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.3.2",
+                        "EncryptedData",
+                        "EncryptedAttribute",
+                        node = node)
+
+            if (encryptedData
+                            .filter { it.attributes.getNamedItem("Type") != null }
+                            .any { it.attributes.getNamedItem("Type").textContent !=
+                                    TestCommon.ELEMENT })
+                throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_7_3_2_a,
+                        property = "Type",
+                        actual = it.attributes.getNamedItem("Type").textContent,
+                        expected = TestCommon.ELEMENT,
+                        node = node)
+            // todo - The encrypted content MUST contain an element that has a type of or derived
+            // from AssertionType.
+        }
+    }
+
+    /** 2.7.3.1 Element <Attribute> **/
+    @Suppress("ComplexCondition")
+    private fun verifyAttribute() {
+        node.allChildren("Attribute").forEach {
+            if (it.attributes.getNamedItem("Name") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.3.1",
+                        "Name",
+                        "Attribute",
+                        node = node)
+
+            val nameAttribute = it.attributes.getNamedItem("Name")
+            val nameFormatAttribute = it.attributes.getNamedItem("NameFormat")
+            val friendlyNameAttr = it.attributes.getNamedItem("FriendlyName")
+
+            if ((nameAttribute != null && nameAttribute.textContent == null)
+                    || (nameFormatAttribute != null && nameFormatAttribute.textContent == null)
+                    || (friendlyNameAttr != null && friendlyNameAttr.textContent == null)) {
+                verifyAttributeValue(it)
+            }
+        }
+    }
+
+    private fun verifyAttributeValue(it: Node) {
+        it.children("AttributeValue").forEach {
+            val nilAttribute = it.attributes.getNamedItemNS(TestCommon.XSI, "nil")?.textContent
+            if (StringUtils.isNotBlank(it.textContent) ||
+                    (nilAttribute != "true" && nilAttribute != "1"))
+                throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_7_3_1_1,
+                        property = "xsi:nil XML attribute",
+                        actual = nilAttribute,
+                        node = node)
+        }
+    }
+
+    /** 2.7.3 Element <AttributeStatement> **/
+    private fun verifyAttributeStatement() {
+        if (node.allChildren("Assertion")
+                        .filter { it.children("AttributeStatement").isNotEmpty() }
+                        .any { it.children("Subject").isEmpty() })
+            throw SAMLComplianceException.create(SAMLCore_2_7_3,
+                    message = "An AttributeStatement was found without a Subject element.",
+                    node = node)
+
+        node.allChildren("AttributeStatement").forEach {
+            if (it.children("Attribute").isEmpty() && it.children("EncryptedAttribute").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.3",
+                        "Attribute or EncryptedAttribute",
+                        "AttributeStatement",
+                        node = node)
+        }
+    }
+
+    /** 2.7.4 Element <AuthzDecisionStatement> **/
+    private fun verifyAuthzDecisionStatement() {
+        node.allChildren("Assertion").forEach {
+            if (it.children("AuthzDecisionStatement").isNotEmpty()
+                    && it.children("Subject").isEmpty())
+                throw SAMLComplianceException.create(SAMLCore_2_7_4,
+                        message = "No Subject element found.",
+                        node = node)
+        }
+
+        node.allChildren("AuthzDecisionStatement").forEach {
+            if (it.attributes.getNamedItem("Resource") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4",
+                        "Resource",
+                        "AuthzDecisionStatement",
+                        node = node)
+            if (it.attributes.getNamedItem("Decision") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4",
+                        "Decision",
+                        "AuthzDecisionStatement",
+                        node = node)
+            if (it.children("Action").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4",
+                        "Action",
+                        "AuthzDecisionStatement",
+                        node = node)
+        }
+    }
+
+    /** 2.7.4.2 Element <Action> **/
+    private fun verifyAction() {
+        val actions = node.allChildren("Action")
+        actions.forEach {
+            if (it.attributes.getNamedItem("Namespace") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.2.7.4.2",
+                        "Namespace",
+                        "Action",
+                        node = node)
+        }
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/SubjectVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/SubjectVerifier.kt
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.internal
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLCore_2_4_1_3
+import org.codice.compliance.SAMLCore_2_5_1_2
+import org.codice.compliance.XMLSignature_4_5
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.utils.TestCommon
+import org.w3c.dom.Node
+import java.time.Instant
+
+internal class SubjectVerifier(val node: Node) {
+
+    fun verify() {
+        verifySubjectConfirmation()
+        verifySubjectConfirmationData()
+    }
+
+    /**
+     * Verify subject elements against the Core Spec
+     * 2.4.1.1 Element <SubjectConfirmation>
+     */
+    private fun verifySubjectConfirmation() {
+        if (node.allChildren("SubjectConfirmation")
+                        .any { it.attributes.getNamedItem("Method") == null })
+            throw SAMLComplianceException
+                    .createWithXmlPropertyReqMessage("SAMLCore.2.4.1.1",
+                            "Method",
+                            "SubjectConfirmation",
+                            node = node)
+    }
+
+    /**
+     * 2.4.1.2 Element <SubjectConfirmationData>
+     * 2.4.1.3 Complex Type KeyInfoConfirmationDataType
+     */
+    private fun verifySubjectConfirmationData() {
+        node.allChildren("SubjectConfirmationData").forEach {
+            // todo - SAML extensions MUST NOT add local (non-namespace-qualified) XML attributes or
+            // XML attributes qualified by a SAML-defined namespace to the
+            // SubjectConfirmationDataType complex type or a derivation of it; such attributes are
+            // reserved for future maintenance and enhancement of SAML itself.
+
+            val notBefore = it.attributes.getNamedItem("NotBefore")
+            val notOnOrAfter = it.attributes.getNamedItem("NotOnOrAfter")
+            if (notBefore != null
+                    && notOnOrAfter != null) {
+                val notBeforeValue = Instant.parse(notBefore.textContent)
+                val notOnOrAfterValue = Instant.parse(notOnOrAfter.textContent)
+                if (notBeforeValue.isAfter(notOnOrAfterValue))
+                    throw SAMLComplianceException.create(SAMLCore_2_5_1_2,
+                            message = "NotBefore element with value $notBeforeValue is not less" +
+                                    "than NotOnOrAfter element with value $notOnOrAfterValue.",
+                            node = node)
+            }
+
+            // KeyInfoConfirmationDataType
+            if (it.attributes
+                            ?.getNamedItemNS(TestCommon.XSI, "type")
+                            ?.textContent?.contains("KeyInfoConfirmationDataType") == true
+                    && it.children("KeyInfo").any { it.children("KeyValue").size > 1 })
+                throw SAMLComplianceException.create(SAMLCore_2_4_1_3, XMLSignature_4_5,
+                        message = "Multiple Keys found within the KeyInfo element.",
+                        node = node)
+        }
+    }
+}


### PR DESCRIPTION
`SamlAssertionsVerifier` is ridiculously large.

I split `SamlAssertionsVerifier` into:
- `AssertionsVerifier`
- `SubjectVerifier`
- `ConditionsVerifier`
- `StatementVerifier`

Note: Each of these is a section under `2 SAML Assertions`.

`SamlAssertionsVerifier` calls the `verify` method in each of the above classes so we don't have to call them individually. I left all these classes in the same file so the only benefit we get right now is clarity and not suppressing the static analysis finding from detekt. 

Should this be done or do you guys think we should leave it as is?