### PR TITLE
Refactored RequestProtocolVerifier

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/RequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/RequestProtocolVerifier.kt
@@ -17,15 +17,18 @@ import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_2_1_a
 import org.codice.compliance.SAMLCore_3_2_1_b
 import org.codice.compliance.SAMLCore_3_2_1_c
-import org.codice.compliance.SAMLCore_3_3_2_2_a
-import org.codice.compliance.SAMLCore_3_3_2_2_b
-import org.codice.compliance.SAMLCore_3_3_2_3
-import org.codice.compliance.allChildren
-import org.codice.compliance.children
 import org.w3c.dom.Node
 
-@Suppress("StringLiteralDuplication")
-class RequestProtocolVerifier(private val request: Node) {
+abstract class RequestProtocolVerifier (open val request: Node) {
+    companion object {
+        private const val ID = "ID"
+        private const val VERSION = "Version"
+        private const val ISSUE_INSTANT = "IssueInstant"
+        private const val REQUEST = "Request"
+        private const val SAML_VERSION = "2.0"
+        private const val SAMLCore_3_2_1 = "SAMLCore.3.2.1"
+    }
+
     /**
      * Verify protocols against the Core Spec document
      * 3.2.1 Complex Type StatusResponseType
@@ -33,14 +36,10 @@ class RequestProtocolVerifier(private val request: Node) {
     fun verifyCoreRequestProtocol() {
         CoreVerifier(request).verify()
         verifyRequestAbstractType()
-        verifyAuthnQueries()
-        verifyAttributeQueries()
-        verifyAuthzDecisionQueries()
-        verifyAuthenticationRequestProtocol()
-        verifyArtifactResolutionProtocol()
-        verifyManageNameIDRequest()
-        verifyNameIdMappingRequest()
+        verify()
     }
+
+    abstract fun verify()
 
     /**
      * Verify the Request Abstract Types
@@ -49,237 +48,31 @@ class RequestProtocolVerifier(private val request: Node) {
      * complex type.
      */
     private fun verifyRequestAbstractType() {
-        if (request.attributes.getNamedItem("ID") == null)
-            throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.2.1",
-                    "ID",
-                    "Request",
+        if (request.attributes.getNamedItem(ID) == null)
+            throw SAMLComplianceException.createWithXmlPropertyReqMessage(SAMLCore_3_2_1,
+                    property = ID,
+                    parent = REQUEST,
                     node = request)
-        verifyIdValues(request.attributes.getNamedItem("ID"), SAMLCore_3_2_1_a)
+        verifyIdValues(request.attributes.getNamedItem(ID), SAMLCore_3_2_1_a)
 
-        if (request.attributes.getNamedItem("Version") == null)
-            throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.2.1",
-                    "Version",
-                    "Request",
+        if (request.attributes.getNamedItem(VERSION) == null)
+            throw SAMLComplianceException.createWithXmlPropertyReqMessage(SAMLCore_3_2_1,
+                    property = VERSION,
+                    parent = REQUEST,
                     node = request)
 
-        if (request.attributes.getNamedItem("Version").textContent != "2.0")
+        if (request.attributes.getNamedItem(VERSION).textContent != SAML_VERSION)
             throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_3_2_1_b,
-                    property = "Version",
-                    actual = request.attributes.getNamedItem("Version").textContent,
-                    expected = "2.0",
+                    property = VERSION,
+                    actual = request.attributes.getNamedItem(VERSION).textContent,
+                    expected = SAML_VERSION,
                     node = request)
 
-        if (request.attributes.getNamedItem("IssueInstant") == null)
-            throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.2.1",
-                    "IssueInstant",
-                    "Request",
+        if (request.attributes.getNamedItem(ISSUE_INSTANT) == null)
+            throw SAMLComplianceException.createWithXmlPropertyReqMessage(SAMLCore_3_2_1,
+                    property = ISSUE_INSTANT,
+                    parent = REQUEST,
                     node = request)
-        verifyTimeValues(request.attributes.getNamedItem("IssueInstant"), SAMLCore_3_2_1_c)
-    }
-
-    /**
-     * Verify the Authn Queries
-     * 3.3.2.2 Element <AuthnQuery>
-     * The <AuthnQuery> message element is used to make the query “What assertions containing
-     * authentication statements are available for this subject?”
-     */
-    private fun verifyAuthnQueries() {
-        // AuthnQuery
-        request.allChildren("AuthnQuery").forEach {
-            val querySessionIndex = it.attributes.getNamedItem("SessionIndex")?.textContent
-            if (querySessionIndex != null
-                    && request.children("Assertion")
-                            .flatMap { ast -> ast.children("AuthnStatements") }
-                            .map { auth -> auth.attributes.getNamedItem("SessionIndex") }
-                            .filterNotNull()
-                            .map { sidx -> sidx.textContent }
-                            .none { t -> t == querySessionIndex }) {
-                throw SAMLComplianceException.create(SAMLCore_3_3_2_2_a,
-                        message = "There was no AuthnStatement in the Assertion that had a " +
-                                "SessionsIndex of $querySessionIndex.",
-                        node = request)
-            }
-
-            //RequestedAuthnContext
-            it.children("RequestedAuthnContext").forEach { verifyRequestedAuthnContext(it) }
-
-            // todo - verify correctness (brandan - I think this is correct but missing a last step:
-            // "<AuthnContext>
-            // element that satisfies the element in the query")
-            if (it.children("RequestedAuthnContext").isNotEmpty()
-                    && request.children("Assertion")
-                            .filter { it.children("AuthnStatement").isNotEmpty() }
-                            .flatMap { it.children("AuthnStatement") }
-                            .filter { it.children("AuthnContext").isNotEmpty() }
-                            .filter { verifyRequestedAuthnContext(it) }
-                            .count() < 1)
-                throw SAMLComplianceException.create(SAMLCore_3_3_2_2_b,
-                        message = "No AuthnStatement element found that meets the criteria.",
-                        node = request)
-        }
-    }
-
-    /**
-     * Verifies the Requested Authn Contexts against the core spec
-     *
-     * 3.3.2.2.1 Element <RequestedAuthnContext>
-     * The <RequestedAuthnContext> element specifies the authentication context requirements of
-     * authentication statements returned in response to a request or query.
-     *
-     * @throws SAMLComplianceException - if the check fails
-     * @return true - if the check succeeds
-     */
-    private fun verifyRequestedAuthnContext(requestedAuthnContext: Node): Boolean {
-        if (requestedAuthnContext.children("AuthnContextClassRef").isEmpty()
-                && requestedAuthnContext.children("AuthnContextDeclRef").isEmpty())
-            throw SAMLComplianceException.createWithXmlPropertyReqMessage("3.3.2.2.1",
-                    "AuthnContextClassRef or AuthnContextDeclRef",
-                    "RequestedAuthnContext",
-                    node = requestedAuthnContext)
-        return true
-    }
-
-    /**
-     * Verify the Attribute Queries
-     *
-     * 3.3.2.3 Element <AttributeQuery>
-     * The <AttributeQuery> element is used to make the query “Return the requested attributes for
-     * this subject.”
-     */
-    private fun verifyAttributeQueries() {
-        val uniqueAttributeQuery = mutableMapOf<String, String>()
-        request.allChildren("AuthnQuery").forEach {
-            val name = it.attributes.getNamedItem("Name")
-            val nameFormat = it.attributes.getNamedItem("NameFormat")
-            if (name != null && nameFormat != null) {
-                if (uniqueAttributeQuery.containsKey(name.textContent)
-                        && uniqueAttributeQuery[name.textContent] == nameFormat.textContent)
-                    throw SAMLComplianceException.create(SAMLCore_3_3_2_3,
-                            message = "There were two Attribute Queries with the same nameFormat " +
-                                    "of ${nameFormat.textContent} and name of ${name.textContent}.",
-                            node = request)
-                else uniqueAttributeQuery.put(name.textContent, nameFormat.textContent)
-            }
-        }
-    }
-
-    /**
-     * Verify the Authz Decision Queries
-     *
-     * 3.3.2.4 Element <AuthzDecisionQuery>
-     * The <AuthzDecisionQuery> element is used to make the query “Should these actions on this
-     * resource be allowed for this subject, given this evidence?”
-     */
-    private fun verifyAuthzDecisionQueries() {
-        request.allChildren("AuthzDecisionQuery").forEach {
-            if (it.attributes.getNamedItem("Resource") == null)
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.3.2.4",
-                        "Resource",
-                        "AuthzDecisionQuery",
-                        node = request)
-
-            if (it.children("Action").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore3.3.2.4",
-                        "Action",
-                        "AuthzDecisionQuery",
-                        node = request)
-        }
-    }
-
-    /**
-     * Verify the Authentication Request Protocol
-     * 3.4.1.3 Element <IDPList>
-     * 3.4.1.3.1 Element <IDPEntry>
-     *
-     * The <IDPEntry> element specifies a single identity provider trusted by the requester to
-     * authenticate the presenter.
-     */
-    private fun verifyAuthenticationRequestProtocol() {
-        // IDPList
-        request.allChildren("IDPList").forEach {
-            if (it.children("IDPEntry").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.4.1.3",
-                        "IDPEntry",
-                        "IDPList",
-                        node = request)
-
-            //IDPEntry
-            it.children("IDPEntry").forEach {
-                if (it.attributes.getNamedItem("ProviderID") == null)
-                    throw SAMLComplianceException
-                            .createWithXmlPropertyReqMessage("SAMLCore.3.4.1.3.1",
-                            "ProviderID",
-                            "IDPEntry",
-                            node = request)
-            }
-        }
-    }
-
-    /**
-     * Verify the Artifact Resolution Protocol
-     * 3.5.1 Element <ArtifactResolve>
-     *
-     * The <ArtifactResolve> message is used to request that a SAML protocol message be returned in
-     * an <ArtifactResponse> message by specifying an artifact that represents the SAML protocol
-     * message.
-     */
-    private fun verifyArtifactResolutionProtocol() {
-        request.allChildren("ArtifactResolve").forEach {
-            if (it.children("Artifact").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.5.1",
-                        "Artifact",
-                        "ArtifactResolve",
-                        node = request)
-        }
-    }
-
-    /**
-     * Verify the Manage Name ID Requests
-     * 3.6.1 Element <ManageNameIDRequest>
-     *
-     * This message has the complex type ManageNameIDRequestType, which extends RequestAbstractType
-     * and adds the following elements
-     */
-    private fun verifyManageNameIDRequest() {
-        request.allChildren("ManageNameIDRequest").forEach {
-            if (it.children("NameID").isEmpty() && it.children("EncryptedID").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.6.1",
-                        "NameID or EncryptedID",
-                        "ManageNameIDRequest",
-                        node = request)
-
-            if (it.children("NewID").isEmpty()
-                    && it.children("NewEncryptedID").isEmpty()
-                    && it.children("Terminate").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.6.1",
-                        "NameID or EncryptedID or Terminate",
-                        "ManageNameIDRequest",
-                        node = request)
-        }
-    }
-
-    /**
-     * Verify the Name Identifier Mapping Request
-     * 3.8.1 Element <NameIDMappingRequest>
-     *
-     * To request an alternate name identifier for a principal from an identity provider, a
-     * requester sends an <NameIDMappingRequest> message.
-     */
-    private fun verifyNameIdMappingRequest() {
-        request.allChildren("NameIDMappingRequest").forEach {
-            if (it.children("BaseID").isEmpty()
-                    && it.children("NameID").isEmpty()
-                    && it.children("EncryptedID").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.8.1",
-                        "BaseID or NameID or EncryptedID",
-                        "NameIDMappingRequest",
-                        node = request)
-
-            if (it.children("NameIDPolicy").isEmpty() && it.children("EncryptedID").isEmpty())
-                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.8.1",
-                        "NameIDPolicy",
-                        "NameIDMappingRequest",
-                        node = request)
-        }
+        verifyTimeValues(request.attributes.getNamedItem(ISSUE_INSTANT), SAMLCore_3_2_1_c)
     }
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/AssertionQueryProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/AssertionQueryProtocolVerifier.kt
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.requests
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLCore_3_3_2_2_a
+import org.codice.compliance.SAMLCore_3_3_2_2_b
+import org.codice.compliance.SAMLCore_3_3_2_3
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.verification.core.RequestProtocolVerifier
+import org.w3c.dom.Node
+
+class AssertionQueryProtocolVerifier (override val request: Node) :
+        RequestProtocolVerifier(request) {
+    companion object {
+        private const val AUTHZ_DECISION_QUERY = "AuthzDecisionQuery"
+        private const val REQUESTED_AUTHN_CONTEXT = "RequestedAuthnContext"
+    }
+
+    /** 3.3 Assertion Query and Request Protocol **/
+    override fun verify() {
+        verifyAuthnQueries()
+        verifyAttributeQueries()
+        verifyAuthzDecisionQueries()
+    }
+
+    /**
+     * Verify the Authn Queries
+     * 3.3.2.2 Element <AuthnQuery>
+     * The <AuthnQuery> message element is used to make the query “What assertions containing
+     * authentication statements are available for this subject?”
+     */
+    private fun verifyAuthnQueries() {
+        // AuthnQuery
+        request.allChildren("AuthnQuery").forEach {
+            val querySessionIndex = it.attributes.getNamedItem("SessionIndex")?.textContent
+            if (querySessionIndex != null
+                    && request.children("Assertion")
+                            .flatMap { ast -> ast.children("AuthnStatements") }
+                            .mapNotNull { auth -> auth.attributes.getNamedItem("SessionIndex") }
+                            .map { sidx -> sidx.textContent }
+                            .none { t -> t == querySessionIndex }) {
+                throw SAMLComplianceException.create(SAMLCore_3_3_2_2_a,
+                        message = "There was no AuthnStatement in the Assertion that had a " +
+                                "SessionsIndex of $querySessionIndex.",
+                        node = request)
+            }
+
+            //RequestedAuthnContext
+            it.children(REQUESTED_AUTHN_CONTEXT).forEach { verifyRequestedAuthnContext(it) }
+
+            // todo - verify correctness (brandan - I think this is correct but missing a last step:
+            // "<AuthnContext>
+            // element that satisfies the element in the query")
+            if (it.children(REQUESTED_AUTHN_CONTEXT).isNotEmpty()
+                    && request.children("Assertion")
+                            .filter { it.children("AuthnStatement").isNotEmpty() }
+                            .flatMap { it.children("AuthnStatement") }
+                            .filter { it.children("AuthnContext").isNotEmpty() }
+                            .filter { verifyRequestedAuthnContext(it) }
+                            .count() < 1)
+                throw SAMLComplianceException.create(SAMLCore_3_3_2_2_b,
+                        message = "No AuthnStatement element found that meets the criteria.",
+                        node = request)
+        }
+    }
+
+    /**
+     * Verifies the Requested Authn Contexts against the core spec
+     *
+     * 3.3.2.2.1 Element <RequestedAuthnContext>
+     * The <RequestedAuthnContext> element specifies the authentication context requirements of
+     * authentication statements returned in response to a request or query.
+     *
+     * @throws SAMLComplianceException - if the check fails
+     * @return true - if the check succeeds
+     */
+    private fun verifyRequestedAuthnContext(requestedAuthnContext: Node): Boolean {
+        if (requestedAuthnContext.children("AuthnContextClassRef").isEmpty()
+                && requestedAuthnContext.children("AuthnContextDeclRef").isEmpty())
+            throw SAMLComplianceException.createWithXmlPropertyReqMessage("3.3.2.2.1",
+                    property = "AuthnContextClassRef or AuthnContextDeclRef",
+                    parent = REQUESTED_AUTHN_CONTEXT,
+                    node = requestedAuthnContext)
+        return true
+    }
+
+    /**
+     * Verify the Attribute Queries
+     *
+     * 3.3.2.3 Element <AttributeQuery>
+     * The <AttributeQuery> element is used to make the query “Return the requested attributes for
+     * this subject.”
+     */
+    private fun verifyAttributeQueries() {
+        val uniqueAttributeQuery = mutableMapOf<String, String>()
+        request.allChildren("AuthnQuery").forEach {
+            val name = it.attributes.getNamedItem("Name")
+            val nameFormat = it.attributes.getNamedItem("NameFormat")
+            if (name != null && nameFormat != null) {
+                if (uniqueAttributeQuery.containsKey(name.textContent)
+                        && uniqueAttributeQuery[name.textContent] == nameFormat.textContent)
+                    throw SAMLComplianceException.create(SAMLCore_3_3_2_3,
+                            message = "There were two Attribute Queries with the same nameFormat " +
+                                    "of ${nameFormat.textContent} and name of ${name.textContent}.",
+                            node = request)
+                else uniqueAttributeQuery[name.textContent] = nameFormat.textContent
+            }
+        }
+    }
+
+    /**
+     * Verify the Authz Decision Queries
+     *
+     * 3.3.2.4 Element <AuthzDecisionQuery>
+     * The <AuthzDecisionQuery> element is used to make the query “Should these actions on this
+     * resource be allowed for this subject, given this evidence?”
+     */
+    private fun verifyAuthzDecisionQueries() {
+        request.allChildren("AuthzDecisionQuery").forEach {
+            if (it.attributes.getNamedItem("Resource") == null)
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.3.2.4",
+                        property = "Resource",
+                        parent = AUTHZ_DECISION_QUERY,
+                        node = request)
+
+            if (it.children("Action").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore3.3.2.4",
+                        property = "Action",
+                        parent = AUTHZ_DECISION_QUERY,
+                        node = request)
+        }
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/AuthnRequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/AuthnRequestProtocolVerifier.kt
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.requests
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.verification.core.RequestProtocolVerifier
+import org.w3c.dom.Node
+
+class AuthnRequestProtocolVerifier (override val request: Node) : RequestProtocolVerifier(request) {
+    companion object {
+        private const val IDP_ENTRY = "IDPEntry"
+        private const val IDP_LIST = "IDPList"
+    }
+
+    /** 3.4 Authentication Request Protocol **/
+    override fun verify() {
+        verifyIdpList()
+    }
+
+    /**
+     * Verify the Authentication Request Protocol
+     * 3.4.1.3 Element <IDPList>
+     * 3.4.1.3.1 Element <IDPEntry>
+     *
+     * The <IDPEntry> element specifies a single identity provider trusted by the requester to
+     * authenticate the presenter.
+     */
+    private fun verifyIdpList() {
+        // IDPList
+        request.allChildren(IDP_LIST).forEach {
+            if (it.children(IDP_ENTRY).isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.4.1.3",
+                        property = IDP_ENTRY,
+                        parent = IDP_LIST,
+                        node = request)
+
+            //IDPEntry
+            it.children("IDPEntry").forEach {
+                if (it.attributes.getNamedItem("ProviderID") == null)
+                    throw SAMLComplianceException
+                            .createWithXmlPropertyReqMessage("SAMLCore.3.4.1.3.1",
+                                    property = "ProviderID",
+                                    parent = IDP_LIST,
+                                    node = request)
+            }
+        }
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/NameIdManagementProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/NameIdManagementProtocolVerifier.kt
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.requests
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.verification.core.RequestProtocolVerifier
+import org.w3c.dom.Node
+
+class NameIdManagementProtocolVerifier (override val request: Node) :
+        RequestProtocolVerifier(request) {
+    companion object {
+        private const val MANAGE_NAME_ID_REQUEST = "ManageNameIDRequest"
+    }
+
+    /** 3.6 Name Identifier Management Protocol **/
+    override fun verify() {
+        verifyManageNameIDRequest()
+    }
+
+    /**
+     * Verify the Manage Name ID Requests
+     * 3.6.1 Element <ManageNameIDRequest>
+     *
+     * This message has the complex type ManageNameIDRequestType, which extends RequestAbstractType
+     * and adds the following elements
+     */
+    private fun verifyManageNameIDRequest() {
+        request.allChildren(MANAGE_NAME_ID_REQUEST).forEach {
+            if (it.children("NameID").isEmpty() && it.children("EncryptedID").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.6.1",
+                        property = "NameID or EncryptedID",
+                        parent = MANAGE_NAME_ID_REQUEST,
+                        node = request)
+
+            if (it.children("NewID").isEmpty()
+                    && it.children("NewEncryptedID").isEmpty()
+                    && it.children("Terminate").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.6.1",
+                        property = "NameID or EncryptedID or Terminate",
+                        parent = MANAGE_NAME_ID_REQUEST,
+                        node = request)
+        }
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/NameIdMappingProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/NameIdMappingProtocolVerifier.kt
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.verification.core.requests
+
+import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.allChildren
+import org.codice.compliance.children
+import org.codice.compliance.verification.core.RequestProtocolVerifier
+import org.w3c.dom.Node
+
+class NameIdMappingProtocolVerifier (override val request: Node) :
+        RequestProtocolVerifier(request) {
+    companion object {
+        private const val NAME_ID_MAPPING_REQUEST = "NameIDMappingRequest"
+    }
+
+    /** 3.8 Name Identifier Mapping Protocol **/
+    override fun verify() {
+        verifyNameIdMappingRequest()
+    }
+
+    /**
+     * Verify the Name Identifier Mapping Request
+     * 3.8.1 Element <NameIDMappingRequest>
+     *
+     * To request an alternate name identifier for a principal from an identity provider, a
+     * requester sends an <NameIDMappingRequest> message.
+     */
+    private fun verifyNameIdMappingRequest() {
+        request.allChildren(NAME_ID_MAPPING_REQUEST).forEach {
+            if (it.children("BaseID").isEmpty()
+                    && it.children("NameID").isEmpty()
+                    && it.children("EncryptedID").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.8.1",
+                        property = "BaseID or NameID or EncryptedID",
+                        parent = NAME_ID_MAPPING_REQUEST,
+                        node = request)
+
+            if (it.children("NameIDPolicy").isEmpty() && it.children("EncryptedID").isEmpty())
+                throw SAMLComplianceException.createWithXmlPropertyReqMessage("SAMLCore.3.8.1",
+                        property = "NameIDPolicy",
+                        parent = NAME_ID_MAPPING_REQUEST,
+                        node = request)
+        }
+    }
+}


### PR DESCRIPTION
Split `RequestProtocolVerifier` into 
- `AssertionQueryProtocolVerifier` (3.3)
- `AuthnRequestProtocolVerifier` (3.4)
- `NameIdManagementProtocolVerifier` (3.6)
- `NameIdMappingProtocolVerifier` (3.8)

`RequestProtocolVerifier` will still be the only class the tests need to call but they have to pass in a `RequestType` enum to specify what Protocol to test.