### PR TITLE
Add markdown files to track test coverage for each spec document

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,17 @@ to a file and pass that file to the `samlconf` script using `-i` or `--implement
 ## Project Structure
 This section will briefly talk about the project structure.
 
-### test
+### ctk
 This module contains all the test related modules: `idp`, `sp`, and `common`.
 
 #### idp
 This module will contain all tests being written against a SAML IdP. The `src` directory of the module is organized by the SAML specification as follows:
+
 * Package: Based on Profile (i.e. WebSSO, Single Logout)
   * Class: Based on Binding (i.e. POST, REDIRECT, ARTIFACT)
 * Class: Based on Metadata
+
+This [coverage](ctk/idp/coverage) directory is used to track which sections of each SAML specification are covered by these tests:
 
 #### sp
 This module will contain all tests being written against a SAML SP. The src directory of the module is organized identically to the idp module.

--- a/ctk/idp/coverage/Bindings.md
+++ b/ctk/idp/coverage/Bindings.md
@@ -1,0 +1,99 @@
+# Bindings Specification
+This file tracks the testing coverage of the SAML Bindings specification.
+
+### Legend
+```diff
++ Fully tested
+- Ignored
+Unmarked sections need attention
+```
+
+### Table of Contents
+```diff
+- 1 Introduction
+-	1.1 Protocol Binding Concepts
+-	1.2 Notation
+- 2 Guidelines for Specifying Additional Protocol Bindings
+3 Protocol Bindings
+-	3.1 General Considerations
+		3.1.1 Use of RelayState
+-		3.1.2 Security
+			3.1.2.1 Use of SSL 3.0 or TLS 1.0
+-			3.1.2.2 Data Origin Authentication
+-			3.1.2.3 Message Integrity
+-			3.1.2.4 Message Confidentiality
+-			3.1.2.5 Security Considerations
+	3.2 SAML SOAP Binding
+		3.2.1 Required Information
+		3.2.2 Protocol-Independent Aspects of the SAML SOAP Binding
+			3.2.2.1 Basic Operation
+			3.2.2.2 SOAP Headers
+		3.2.3 Use of SOAP over HTTP
+			3.2.3.1 HTTP Headers
+			3.2.3.2 Caching
+			3.2.3.3 Error Reporting
+			3.2.3.4 Metadata Considerations
+			3.2.3.5 Example SAML Message Exchange Using SOAP over HTTP
+	3.3 Reverse SOAP (PAOS) Binding
+		3.3.1 Required Information
+		3.3.2 Overview
+		3.3.3 Message Exchange
+			3.3.3.1 HTTP Request, SAML Request in SOAP Response
+			3.3.3.2 SAML Response in SOAP Request, HTTP Response
+		3.3.4 Caching
+		3.3.5 Security Considerations
+			3.3.5.1 Error Reporting
+			3.3.5.2 Metadata Considerations
+-	3.4 HTTP Redirect Binding
+-		3.4.1 Required Information
+-		3.4.2 Overview
+		3.4.3 RelayState
+		3.4.4 Message Encoding
+			3.4.4.1 DEFLATE Encoding
+		3.4.5 Message Exchange
+-			3.4.5.1 HTTP and Caching Considerations
+			3.4.5.2 Security Considerations
++		3.4.6 Error Reporting
+-		3.4.7 Metadata Considerations
+-		3.4.8 Example SAML Message Exchange Using HTTP Redirect
+-	3.5 HTTP POST Binding
+-		3.5.1 Required Information
+-		3.5.2 Overview
+		3.5.3 RelayState
++		3.5.4 Message Encoding
+-		3.5.5 Message Exchange
+-			3.5.5.1 HTTP and Caching Considerations
+			3.5.5.2 Security Considerations
++		3.5.6 Error Reporting
+-		3.5.7 Metadata Considerations
+-		3.5.8 Example SAML Message Exchange Using HTTP POST
+-	3.6 HTTP Artifact Binding
+		3.6.1 Required Information
+		3.6.2 Overview
+		3.6.3 Message Encoding
+			3.6.3.1 RelayState
+			3.6.3.2 URL Encoding
+			3.6.3.3 Form Encoding
+		3.6.4 Artifact Format
+			3.6.4.1 Required Information
+			3.6.4.2 Format Details
+		3.6.5 Message Exchange
+			3.6.5.1 HTTP and Caching Considerations
+			3.6.5.2 Security Considerations
+		3.6.6 Error Reporting
+		3.6.7 Metadata Considerations
+		3.6.8 Example SAML Message Exchange Using HTTP Artifact
+	3.7 SAML URI Binding
+		3.7.1 Required Information
+		3.7.2 Protocol-Independent Aspects of the SAML URI Binding
+			3.7.2.1 Basic Operation
+		3.7.3 Security Considerations
+		3.7.4 MIME Encapsulation
+		3.7.5 Use of HTTP URIs
+			3.7.5.1 URI Syntax
+			3.7.5.2 HTTP and Caching Considerations
+			3.7.5.3 Security Considerations
+			3.7.5.4 Error Reporting
+			3.7.5.5 Metadata Considerations
+			3.7.5.6 Example SAML Message Exchange Using an HTTP URI
+```

--- a/ctk/idp/coverage/Core.md
+++ b/ctk/idp/coverage/Core.md
@@ -1,0 +1,171 @@
+# Core Specification
+This file tracks the testing coverage of the SAML Core specification.
+
+### Legend
+```diff
++ Fully tested
+- Ignored
+Unmarked sections need attention
+```
+
+### Table of Contents
+```diff
+ 1 Introduction
+-	1.1 Notation
+-	1.2 Schema Organization and Namespaces
+	1.3 Common Data Types
+		1.3.1 String Values
++		1.3.2 URI Values
+		1.3.3 Time Values
+		1.3.4 ID and ID Reference Values
+2 SAML Assertions
+-	2.1 Schema Header and Namespace Declarations
+	2.2 Name Identifiers
+-		2.2.1 Element <BaseID>
+-		2.2.2 Complex Type NameIDType
+-		2.2.3 Element <NameID>
+		2.2.4 Element <EncryptedID>
+-		2.2.5 Element <Issuer>
+	2.3 Assertions
+-		2.3.1 Element <AssertionIDRef>
+-		2.3.2 Element <AssertionURIRef>
+		2.3.3 Element <Assertion>
+		2.3.4 Element <EncryptedAssertion>
+	2.4 Subjects
+		2.4.1 Element <Subject>
++			2.4.1.1 Element <SubjectConfirmation>
+			2.4.1.2 Element <SubjectConfirmationData>
+			2.4.1.3 Complex Type KeyInfoConfirmationDataType
+-			2.4.1.4 Example of a Key-Confirmed <Subject>
+	2.5 Conditions
+		2.5.1 Element <Conditions>
+			2.5.1.1 General Processing Rules
++			2.5.1.2 Attributes NotBefore and NotOnOrAfter
+-			2.5.1.3 Element <Condition>
+			2.5.1.4 Elements <AudienceRestriction> and <Audience>
+			2.5.1.5 Element <OneTimeUse>
+			2.5.1.6 Element <ProxyRestriction>
+-	2.6 Advice
+-		2.6.1 Element <Advice>
+	2.7 Statements
+-		2.7.1 Element <Statement>
++		2.7.2 Element <AuthnStatement>
+-			2.7.2.1 Element <SubjectLocality>
+-			2.7.2.2 Element <AuthnContext>
+		2.7.3 Element <AttributeStatement>
+			2.7.3.1 Element <Attribute>
++				2.7.3.1.1 Element <AttributeValue>
+			2.7.3.2 Element <EncryptedAttribute>
+		2.7.4 Element <AuthzDecisionStatement>
+-			2.7.4.1 Simple Type DecisionType
++			2.7.4.2 Element <Action>
+-			2.7.4.3 Element <Evidence>
+3 SAML Protocols
+-	3.1 Schema Header and Namespace Declarations
+	3.2 Requests and Responses
++		3.2.1 Complex Type RequestAbstractType
+		3.2.2 Complex Type StatusResponseType
++			3.2.2.1 Element <Status>
++			3.2.2.2 Element <StatusCode>
+-			3.2.2.3 Element <StatusMessage>
+-			3.2.2.4 Element <StatusDetail>
+	3.3 Assertion Query and Request Protocol
+-		3.3.1 Element <AssertionIDRequest>
+-		3.3.2 Queries
+-			3.3.2.1 Element <SubjectQuery>
+-			3.3.2.2 Element <AuthnQuery>
+-				3.3.2.2.1 Element <RequestedAuthnContext>
+-			3.3.2.3 Element <AttributeQuery>
+-			3.3.2.4 Element <AuthzDecisionQuery>
+-		3.3.3 Element <Response>
+		3.3.4 Processing Rules
++	3.4 Authentication Request Protocol
+		3.4.1 Element <AuthnRequest>
+			3.4.1.1 Element <NameIDPolicy>
+-			3.4.1.2 Element <Scoping>
+-			3.4.1.3 Element <IDPList>
+-				3.4.1.3.1 Element <IDPEntry>
+			3.4.1.4 Processing Rules
+-			3.4.1.5 Proxying
+				3.4.1.5.1 Proxying Processing Rules
+-	3.5 Artifact Resolution Protocol
+-		3.5.1 Element <ArtifactResolve>
+-		3.5.2 Element <ArtifactResponse>
+-		3.5.3 Processing Rules
+-	3.6 Name Identifier Management Protocol
+-		3.6.1 Element <ManageNameIDRequest>
+-		3.6.2 Element <ManageNameIDResponse>
+-		3.6.3 Processing Rules
+-	3.7 Single Logout Protocol
++		3.7.1 Element <LogoutRequest>
+-		3.7.2 Element <LogoutResponse>
+-		3.7.3 Processing Rules
+-			3.7.3.1 Session Participant Rules
+-			3.7.3.2 Session Authority Rules
+-	3.8 Name Identifier Mapping Protocol
+-		3.8.1 Element <NameIDMappingRequest>
+-		3.8.2 Element <NameIDMappingResponse>
+-		3.8.3 Processing Rules
+4 SAML Versioning
+	4.1 SAML Specification Set Version
+-		4.1.1 Schema Version
+		4.1.2 SAML Assertion Version
+		4.1.3 SAML Protocol Version
+-			4.1.3.1 Request Version
+			4.1.3.2 Response Version
+			4.1.3.3 Permissible Version Combinations
+	4.2 SAML Namespace Version
+-		4.2.1 Schema Evolution
+5 SAML and XML Signature Syntax and Processing
+-	5.1 Signing Assertions
+-	5.2 Request/Response Signing
+-	5.3 Signature Inheritance
+	5.4 XML Signature Profile
++		5.4.1 Signing Formats and Algorithms
++		5.4.2 References
+-		5.4.3 Canonicalization Method
+		5.4.4 Transforms
+-		5.4.5 [E91] Object
+-		5.4.6 KeyInfo
+-		5.4.7 Example
+6 SAML and XML Encryption Syntax and Processing
++	6.1 General Considerations
+-	6.2 [E93] Encryption and Integrity Protection
+-	6.3 [E43] Key and Data Referencing Guidelines
+-	6.4 Examples
+- 7 SAML Extensibility
+-	7.1 Schema Extension
+-		7.1.1 Assertion Schema Extension
+-		7.1.2 Protocol Schema Extension
+-	7.2 Schema Wildcard Extension Points
+-		7.2.1 Assertion Extension Points
+-		7.2.2 Protocol Extension Points
+-	7.3 Identifier Extension
+8 SAML-Defined Identifiers
+	8.1 Action Namespace Identifiers
+-		8.1.1 Read/Write/Execute/Delete/Control
+		8.1.2 Read/Write/Execute/Delete/Control with Negation
+-		8.1.3 Get/Head/Put/Post
+-		8.1.4 UNIX File Permissions
+-	8.2 Attribute Name Format Identifiers
+-		8.2.1 Unspecified
+-		8.2.2 URI Reference
+		8.2.3 Basic
+-	8.3 Name Identifier Format Identifiers
+-		8.3.1 Unspecified
+-		8.3.2 Email Address
+-			8.3.3 X.509 Subject Name
+-		8.3.4 Windows Domain Qualified Name
+-		8.3.5 Kerberos Principal Name
+		8.3.6 Entity Identifier
+		8.3.7 Persistent Identifier
+		8.3.8 Transient Identifier
+-	8.4 Consent Identifiers
+-		8.4.1 Unspecified
+-		8.4.2 Obtained
+-		8.4.3 Prior
+-		8.4.4 Implicit
+-		8.4.5 Explicit
+-		8.4.6 Unavailable
+-		8.4.7 Inapplicable
+```

--- a/ctk/idp/coverage/Profiles.md
+++ b/ctk/idp/coverage/Profiles.md
@@ -1,0 +1,168 @@
+# Profiles Specification
+This file tracks the testing coverage of the SAML Profiles specification.
+
+### Legend
+```diff
++ Fully tested
+- Ignored
+Unmarked sections need attention
+```
+
+### Table of Contents
+```diff
+- 1 Introduction
+-	1.1 Profile Concepts
+-	1.2 Notation
+- 2 Specification of Additional Profiles
+-	2.1 Guidelines for Specifying Profiles
+-	2.2 Guidelines for Specifying Attribute Profiles
+- 3 Confirmation Method Identifiers
+-	3.1 Holder of Key
+-	3.2 Sender Vouches
+-	3.3 Bearer
+4 SSO Profiles of SAML
+-	4.1 Web Browser SSO Profile
+-		4.1.1 Required Information
+-		4.1.2 Profile Overview
+		4.1.3 Profile Description
+-			4.1.3.1 HTTP Request to Service Provider
+-			4.1.3.2 Service Provider Determines Identity Provider
+			4.1.3.3 <AuthnRequest> Is Issued by Service Provider to Identity Provider
+			4.1.3.4 Identity Provider Identifies Principal
+			4.1.3.5 Identity Provider Issues <Response> to Service Provider
+-			4.1.3.6 Service Provider Grants or Denies Access to User Agent
+		4.1.4 Use of Authentication Request Protocol
+			4.1.4.1 <AuthnRequest> Usage
+			4.1.4.2 <Response> Usage
+-			4.1.4.3 <Response> Message Processing Rules
+-			4.1.4.4 Artifact-Specific <Response> Message Processing Rules
++			4.1.4.5 POST-Specific Processing Rules
+-		4.1.5 Unsolicited Responses
+-		4.1.6 [E90] Use of Relay State
+-		4.1.7 Use of Metadata
+	4.2 Enhanced Client or Proxy (ECP) Profile
+		4.2.1 Required Information
+		4.2.2 Profile Overview
+		4.2.3 Profile Description
+			4.2.3.1 ECP issues HTTP Request to Service Provider
+			4.2.3.2 Service Provider Issues <AuthnRequest> to ECP
+			4.2.3.3 ECP Determines Identity Provider
+			4.2.3.4 ECP issues <AuthnRequest> to Identity Provider
+			4.2.3.5 Identity Provider Identifies Principal
+			4.2.3.6 Identity Provider issues <Response> to ECP, targeted at service provider
+			4.2.3.7 ECP Conveys <Response> Message to Service Provider
+			4.2.3.8 Service Provider Grants or Denies Access to Principal
+		4.2.4 ECP Profile Schema Usage
+			4.2.4.1 PAOS Request Header Block: SP to ECP
+			4.2.4.2 ECP Request Header Block: SP to ECP
+			4.2.4.3 ECP RelayState Header Block: SP to ECP
+			4.2.4.4 ECP Response Header Block: IdP to ECP
+			4.2.4.5 PAOS Response Header Block: ECP to SP
+		4.2.5 Security Considerations
+		4.2.6 [E20]Use of Metadata
+	4.3 Identity Provider Discovery Profile
+		4.3.1 [E32]Required Information
+		4.3.2 Common Domain Cookie
+		4.3.3 Setting the Common Domain Cookie
+		4.3.4 Obtaining the Common Domain Cookie
+	4.4 Single Logout Profile
+		4.4.1 Required Information
+		4.4.2 Profile Overview
+		4.4.3 Profile Description
+			4.4.3.1 <LogoutRequest> Issued by Session Participant to Identity Provider
+			4.4.3.2 Identity Provider Determines Session Participants
+			4.4.3.3 <LogoutRequest> Issued by Identity Provider to Session Participant/Authority
+			4.4.3.4 Session Participant/Authority Issues <LogoutResponse> to Identity Provider
+			4.4.3.5 Identity Provider Issues <LogoutResponse> to Session Participant
+		4.4.4 Use of Single Logout Protocol
+			4.4.4.1 <LogoutRequest> Usage
+			4.4.4.2 <LogoutResponse> Usage
+		4.4.5 Use of Metadata
+	4.5 Name Identifier Management Profile
+		4.5.1 Required Information
+		4.5.2 Profile Overview
+		4.5.3 Profile Description
+			4.5.3.1 <ManageNameIDRequest> Issued by Requesting Identity/Service Provider
+			4.5.3.2 <ManageNameIDResponse> issued by Responding Identity/Service Provider
+		4.5.4 Use of Name Identifier Management Protocol
+			4.5.4.1 <ManageNameIDRequest> Usage
+			4.5.4.2 <ManageNameIDResponse> Usage
+		4.5.5 Use of Metadata
+5 Artifact Resolution Profile
+	5.1 Required Information
+	5.2 Profile Overview
+	5.3 Profile Description
+		5.3.1 <ArtifactResolve> issued by Requesting Entity
+		5.3.2 <ArtifactResponse> issued by Responding Entity
+	5.4 Use of Artifact Resolution Protocol
+		5.4.1 <ArtifactResolve> Usage
+		5.4.2 <ArtifactResponse> Usage
+	5.5 Use of Metadata
+6 Assertion Query/Request Profile
+	6.1 Required Information
+	6.2 Profile Overview
+	6.3 Profile Description
+		6.3.1 Query/Request issued by SAML Requester
+		6.3.2 <Response> issued by SAML Authority
+	6.4 Use of Query/Request Protocol
+		6.4.1 Query/Request Usage
+		6.4.2 <Response> Usage
+	6.5 Use of Metadata
+7 Name Identifier Mapping Profile
+	7.1 Required Information
+	7.2 Profile Overview
+	7.3 Profile Description
+		7.3.1 <NameIDMappingRequest> issued by Requesting Entity
+		7.3.2 <NameIDMappingResponse> issued by Identity Provider
+	7.4 Use of Name Identifier Mapping Protocol
+		7.4.1 <NameIDMappingRequest> Usage
+		7.4.2 <NameIDMappingResponse> Usage
+			7.4.2.1 Limiting Use of Mapped Identifier
+	7.5 Use of Metadata
+8 SAML Attribute Profiles
+	8.1 Basic Attribute Profile
+		8.1.1 Required Information
+		8.1.2 SAML Attribute Naming
+			8.1.2.1 Attribute Name Comparison
+		8.1.3 Profile-Specific XML Attributes
+		8.1.4 SAML Attribute Values
+		8.1.5 Example
+		8.2 X.500/LDAP Attribute Profile [E53] – Deprecated
+		8.2.1 Required Information
+		8.2.2 SAML Attribute Naming
+			8.2.2.1 Attribute Name Comparison
+		8.2.3 Profile-Specific XML Attributes
+		8.2.4 SAML Attribute Values
+		8.2.5 Profile-Specific Schema
+		8.2.6 Example
+	8.3 UUID Attribute Profile
+		8.3.1 Required Information
+		8.3.2 UUID and GUID Background
+		8.3.3 SAML Attribute Naming
+			8.3.3.1 Attribute Name Comparison
+		8.3.4 Profile-Specific XML Attributes
+		8.3.5 SAML Attribute Values
+		8.3.6 Example
+	8.4 DCE PAC Attribute Profile
+		8.4.1 Required Information
+		8.4.2 PAC Description
+		8.4.3 SAML Attribute Naming
+			8.4.3.1 Attribute Name Comparison
+		8.4.4 Profile-Specific XML Attributes
+		8.4.5 SAML Attribute Values
+		8.4.6 Attribute Definitions
+			8.4.6.1 Realm
+			8.4.6.2 Principal
+			8.4.6.3 Primary Group
+			8.4.6.4 Groups
+			8.4.6.5 Foreign Groups
+		8.4.7 Example
+	8.5 XACML Attribute Profile
+		8.5.1 Required Information
+		8.5.2 SAML Attribute Naming
+			8.5.2.1 Attribute Name Comparison
+		8.5.3 Profile-Specific XML Attributes
+		8.5.4 SAML Attribute Values
+		8.5.5 Profile-Specific Schema
+		8.5.6 Example
+```


### PR DESCRIPTION
I used the markings from our spec document copies to create these tables of contents. If there were any todos, I left the section unmarked (looks like many sections are only partially covered)