### PR TITLE
Core-8.2 Verify attribute name format identifiers

### DIFF
--- a/ctk/idp/coverage/Core.md
+++ b/ctk/idp/coverage/Core.md
@@ -147,10 +147,10 @@ Unmarked sections need attention
 		8.1.2 Read/Write/Execute/Delete/Control with Negation
 -		8.1.3 Get/Head/Put/Post
 -		8.1.4 UNIX File Permissions
--	8.2 Attribute Name Format Identifiers
--		8.2.1 Unspecified
--		8.2.2 URI Reference
-		8.2.3 Basic
++	8.2 Attribute Name Format Identifiers
++		8.2.1 Unspecified
++		8.2.2 URI Reference
++		8.2.3 Basic
 -	8.3 Name Identifier Format Identifiers
 -		8.3.1 Unspecified
 -		8.3.2 Email Address

--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -146,6 +146,9 @@ object SAMLCore_6_1_b : SAMLCoreRefMessage()
 
 object SAMLCore_8_1_2 : SAMLCoreRefMessage()
 
+object SAMLCore_8_2_2 : SAMLCoreRefMessage()
+object SAMLCore_8_2_3 : SAMLCoreRefMessage()
+
 //-----------------
 // BINDINGS
 //-----------------

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -261,6 +261,12 @@ SAMLCore_6_1_b=The <EncryptedData> element's Type attribute SHOULD be used and, 
 SAMLCore_8_1_2=A SAML authority MUST NOT authorize both an action and its negated form [in the \
   Namespace attribute of the <Action> element].
 
+SAMLCore_8_2_2=The attribute name MUST follow the convention for URI references (see RFC 2396) \
+  [when using the Uri name attribute format]
+
+SAMLCore_8_2_3=The class of strings acceptable as the attribute name MUST be drawn from the set \
+  of values belonging to the primitive type xs:Name [when using the Basic name attribute format]
+
 #------------------
 # BINDINGS
 #------------------


### PR DESCRIPTION
Added a check for the URI and Basic attribute name formats (the URI doesn't get checked by our common data types URI validator)