### PR TITLE
MAINT - Changes prettyPrintXml functionality to use the HTML output method

### DIFF
--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -22,7 +22,6 @@ import org.codice.security.saml.SamlProtocol
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 import java.io.File
-import java.io.StringReader
 import java.io.StringWriter
 import java.nio.charset.StandardCharsets
 import javax.xml.parsers.DocumentBuilderFactory
@@ -31,7 +30,6 @@ import javax.xml.transform.Transformer
 import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
-import javax.xml.transform.stream.StreamSource
 import javax.xml.xpath.XPathConstants
 import javax.xml.xpath.XPathFactory
 import kotlin.test.currentStackTrace
@@ -164,25 +162,19 @@ fun Node.prettyPrintXml(): String {
     return output.toString()
 }
 
-//@Suppress("TooGenericExceptionCaught")
-//fun String.prettyPrintXml(): String {
-//    return try {
-//        Common.buildDom(this).prettyPrintXml()
-//    } catch (e: Exception) {
-//        Log.debugWithSupplier { "'$this' is not valid XML." }
-//        this
-//    }
-//}
+@Suppress("TooGenericExceptionCaught")
 fun String.prettyPrintXml(): String {
-    // Escape all ampersands because Keycloak does not properly escape it in POST responses
-    // which causes the transform to fail.
-    val escapedString = this.replace(Regex("&([^;]+(?!(?:\\\\w|;)))"),
-            { match -> "&amp;${match.value.removePrefix("&")}" })
-    val input = StreamSource(StringReader(escapedString))
-    val output = StreamResult(StringWriter())
-    val transformer = createTransformer()
-    transformer.transform(input, output)
-    return output.writer.toString()
+    return try {
+        // Escape all ampersands because Keycloak does not properly escape it in POST responses
+        // which causes the transform to fail.
+        val escapedString = this.replace(Regex("&([^;]+(?!(?:\\\\w|;)))"),
+                { match -> "&amp;${match.value.removePrefix("&")}" })
+
+        Common.buildDom(escapedString).prettyPrintXml()
+    } catch (e: Exception) {
+        Log.debugWithSupplier { "'$this' is not valid XML." }
+        this
+    }
 }
 
 fun String.debugPrettyPrintXml(header: String?) {
@@ -196,6 +188,7 @@ private fun createTransformer(): Transformer {
     return TransformerFactory.newInstance().newTransformer().apply {
         setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name())
         setOutputProperty(OutputKeys.INDENT, "yes")
+        setOutputProperty(OutputKeys.METHOD, "html")
         setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
         setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
     }


### PR DESCRIPTION
This should resolve formatting/indenting for both xml and html input.