### PR TITLE
[WIP] Profiles 4.1.4.2 - Added a comparison for two Subjects

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/SubjectsComparison.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/SubjectsComparison.kt
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance.utils
+
+import org.codice.compliance.children
+import org.w3c.dom.Node
+
+class SubjectsComparison(private val subject1: Node, private val subject2: Node) {
+    /**
+     * Compares two subjects according to the Core document section 3.3.4
+     */
+    fun subjectsMatch(): Boolean {
+        return idMatch() && subjectConfirmationMatch()
+    }
+
+    private fun subjectConfirmationMatch(): Boolean {
+        val subjectConfirmation1 = subject1.children("SubjectConfirmation")
+        val subjectConfirmation2 = subject2.children("SubjectConfirmation")
+
+        if (subjectConfirmation1.isNotEmpty() && subjectConfirmation2.isNotEmpty()) {
+
+            subjectConfirmation1.forEachIndexed { _, sc1 ->
+                subjectConfirmation2.forEachIndexed { _, sc2 ->
+                    if (sc1.attributes.getNamedItem("Method") ==
+                            sc2.attributes.getNamedItem("Method"))
+                        return true
+                }
+            }
+        }
+        return false
+    }
+
+    @SuppressWarnings("ReturnCount")
+    private fun idMatch(): Boolean {
+        val subject1Name = subject1.localName
+        val subject2Name = subject2.localName
+        if (subject1Name == "EncryptedID") {
+            // decrypt
+        }
+
+        if (subject2Name == "EncryptedID") {
+            // decrypt
+        }
+
+        if (subject1Name != subject2Name)
+            return baseIdsMatch()
+
+        when (subject1Name) {
+            "BaseID" -> return baseIdsMatch()
+            "NameID" -> return nameIdsMatch()
+        }
+        return false
+    }
+
+    private fun baseIdsMatch(): Boolean {
+        return compareAttributes("NameQualifier")
+                && compareAttributes("SPNameQualifier")
+    }
+
+    private fun nameIdsMatch(): Boolean {
+        return baseIdsMatch()
+                && compareAttributes("Format")
+                && compareAttributes("SPProvidedID")
+    }
+
+    private fun compareAttributes(attribute: String): Boolean {
+        return subject1.attributes.getNamedItem(attribute).textContent ==
+                subject2.attributes.getNamedItem(attribute).textContent
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -114,7 +114,7 @@ class TestCommon {
                     SAMLComplianceException::class.java.classLoader)
         }
 
-        /*
+        /**
          * Since errors shouldn't be passed to user implementations, this acts as the "user
          * implementation" and parses the response into the correct idp object for further
          * processing.

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseProtocolVerifier.kt
@@ -50,7 +50,7 @@ class ResponseProtocolVerifier(private val response: Node,
         verifyStatusesType()
         verifyNameIdMappingResponse()
 
-        if (response.localName == "AuthnRequest") {
+        if (response.localName == "Response") {
             response.children("Assertion")
                     .forEach {
                         if (it.children("AuthnStatement").isEmpty())

--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -50,7 +50,6 @@ sealed class XmlSigRefMessage : SAMLSpecRefMessage("XMLSig.doc", "XMLSig.uri")
 // PROFILES
 //-----------------
 object SAMLProfiles_3_1_a : SAMLProfileRefMessage()
-
 object SAMLProfiles_3_1_b : SAMLProfileRefMessage()
 object SAMLProfiles_3_1_c : SAMLProfileRefMessage()
 
@@ -62,6 +61,7 @@ object SAMLProfiles_4_1_4_2_a : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_b : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_c : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_d : SAMLProfileRefMessage()
+object SAMLProfiles_4_1_4_2_e : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_f : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_g : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_h : SAMLProfileRefMessage()
@@ -69,6 +69,7 @@ object SAMLProfiles_4_1_4_2_i : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_j : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_k : SAMLProfileRefMessage()
 object SAMLProfiles_4_1_4_2_l : SAMLProfileRefMessage()
+
 object SAMLProfiles_4_1_4_5 : SAMLProfileRefMessage()
 
 //-----------------

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -39,8 +39,8 @@ SAMLProfiles_4_1_4_2_c=The Format attribute MUST be omitted or have a value of \
 
 SAMLProfiles_4_1_4_2_d=[A Response] MUST contain at least one <Assertion>.
 
-#SAMLProfiles_4_1_4_2e(If multiple assertions are included, then each assertion's <Subject> element
-# MUST refer to the same principal.
+SAMLProfiles_4_1_4_2_e=If multiple assertions are included, then each assertion's <Subject> element \
+ MUST refer to the same principal.
 
 SAMLProfiles_4_1_4_2_g=Any assertion issued for consumption using this profile MUST contain a \
   <Subject> element with at least one <SubjectConfirmation> element containing a Method of \


### PR DESCRIPTION
## 4.1.4.2 - <Response> Usage

```
If multiple assertions are included, then each assertion's <Subject> element MUST refer 
to the same principal. It is allowable for the content of the <Subject> elements to differ 
(e.g. using different <NameID> or alternative <SubjectConfirmation> elements).
```

These `MUST`s in `Core - 3.3.4` are required to test the statement above

```
A <saml:Subject> element S1 strongly matches S2 if and only if the following two 
conditions both apply:

- If S2 includes an identifier element (<BaseID>, <NameID>,  or <EncryptedID>), 
then S1 MUST include an identical identifier element, but the element MAY be 
encrypted (or not) in either S1 or S2. In other words, the decrypted form of the 
identifier MUST be identical in S1 and S2. "Identical" means that the identifier 
element's content and attribute values MUST be the same. An encrypted 
identifier will be identical to the original according to this definition, once 
decrypted.

- If S2 includes one or more <saml:SubjectConfirmation> elements, then S1 
MUST include at least one <saml:SubjectConfirmation> element such that S1 
can be confirmed in the manner described by at least one
<saml:SubjectConfirmation> element in S2.

As an example of what is and is not permitted, S1 could contain a 
<saml:NameID> with a particular Format value, and S2 could contain a 
<saml:EncryptedID> element that is the result of encrypting S1's 
<saml:NameID> element. However, S1 and S2 cannot contain a 
<saml:NameID> element with different Format values and element 
content, even if the two identifiers are considered to refer to the
same principal.
```