### PR TITLE
Core - Added verification for SAML extensions

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -21,17 +21,51 @@ import org.codice.compliance.SAMLCore_5_4_2_a
 import org.codice.compliance.SAMLCore_5_4_2_b
 import org.codice.compliance.SAMLCore_5_4_2_b1
 import org.codice.compliance.SAMLCore_6_1_b
+import org.codice.compliance.SAMLCore_SamlExtensions
 import org.codice.compliance.SAMLSpecRefMessage
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
+import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.TestCommon.Companion.ELEMENT
 import org.codice.compliance.utils.TestCommon.Companion.REQUESTER
 import org.codice.compliance.verification.core.CommonDataTypeVerifier.Companion.verifyCommonDataType
+import org.w3c.dom.Attr
+import org.w3c.dom.Element
 import org.w3c.dom.Node
 
 class CoreVerifier(val node: Node) {
     companion object {
         private const val ENCRYPTED_DATA = "EncryptedData"
+
+        /**
+         * Verify SAML extension attributes or elements against the Core Spec document
+         *
+         * 2.4.1.2 Element <SubjectConfirmationData>
+         * 2.7.3.1 Element <Attribute>
+         * 3.2.1 Complex Type RequestAbstractType
+         * 3.2.2 Complex Type StatusResponseType
+         */
+        internal fun verifySamlExtensions(nodes: List<Node>,
+                                          expectedSamlNames: List<String>) {
+            nodes.forEach {
+                if (isNullNamespace(it) || (it.namespaceURI == TestCommon.SAML_NAMESPACE
+                                && !expectedSamlNames.contains(it.localName))) {
+                    throw SAMLComplianceException.create(SAMLCore_SamlExtensions,
+                            message = "An invalid SAML extension was found.",
+                            node = it)
+                }
+            }
+        }
+
+        private fun isNullNamespace(node: Node): Boolean {
+            return with (node) {
+                when (this) {
+                    is Attr -> namespaceURI == null && ownerElement.namespaceURI == null
+                    is Element -> namespaceURI == null
+                    else -> throw UnknownError("Unknown Node type found")
+                }
+            }
+        }
     }
 
     /**

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -48,7 +48,7 @@ class CoreVerifier(val node: Node) {
         internal fun verifySamlExtensions(nodes: List<Node>,
                                           expectedSamlNames: List<String>) {
             nodes.forEach {
-                if (isNullNamespace(it) || (it.namespaceURI == TestCommon.SAML_NAMESPACE
+                if (isNullNamespace(it) || (isSamlNamespace(it)
                                 && !expectedSamlNames.contains(it.localName))) {
                     throw SAMLComplianceException.create(SAMLCore_SamlExtensions,
                             message = "An invalid SAML extension was found.",
@@ -58,10 +58,23 @@ class CoreVerifier(val node: Node) {
         }
 
         private fun isNullNamespace(node: Node): Boolean {
-            return with (node) {
+            return with(node) {
                 when (this) {
                     is Attr -> namespaceURI == null && ownerElement.namespaceURI == null
                     is Element -> namespaceURI == null
+                    else -> throw UnknownError("Unknown Node type found")
+                }
+            }
+        }
+
+        private fun isSamlNamespace(node: Node): Boolean {
+            return with(node) {
+                when (this) {
+                    is Attr -> {
+                        namespaceURI == TestCommon.SAML_NAMESPACE
+                                || ownerElement.namespaceURI == TestCommon.SAML_NAMESPACE
+                    }
+                    is Element -> namespaceURI == TestCommon.SAML_NAMESPACE
                     else -> throw UnknownError("Unknown Node type found")
                 }
             }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/RequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/RequestProtocolVerifier.kt
@@ -17,9 +17,10 @@ import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_2_1_a
 import org.codice.compliance.SAMLCore_3_2_1_b
 import org.codice.compliance.SAMLCore_3_2_1_c
+import org.codice.compliance.children
 import org.w3c.dom.Node
 
-abstract class RequestProtocolVerifier (open val request: Node) {
+abstract class RequestProtocolVerifier(open val request: Node) {
     companion object {
         private const val ID = "ID"
         private const val VERSION = "Version"
@@ -75,5 +76,8 @@ abstract class RequestProtocolVerifier (open val request: Node) {
                     node = request)
         CommonDataTypeVerifier.verifyTimeValues(request.attributes.getNamedItem(ISSUE_INSTANT),
                 SAMLCore_3_2_1_c)
+
+        CoreVerifier.verifySamlExtensions(request.children(),
+                expectedSamlNames = listOf("Issuer", "Signature"))
     }
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseProtocolVerifier.kt
@@ -40,6 +40,7 @@ class ResponseProtocolVerifier(private val response: Node,
         private const val ISSUE_INSTANT = "IssueInstant"
         private const val SAMLCore_3_2_2 = "SAMLCore.3.2.2"
     }
+
     /**
      * Verify protocols against the Core Spec document
      * 3.2.2 Complex Type StatusResponseType
@@ -120,6 +121,10 @@ class ResponseProtocolVerifier(private val response: Node,
                     property = STATUS,
                     parent = RESPONSE,
                     node = response)
+
+        CoreVerifier.verifySamlExtensions(response.children(),
+                expectedSamlNames = listOf("Issuer", "Signature", "Status", "Assertion",
+                        "EncryptedAssertion"))
     }
 
     /**

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/StatementVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/StatementVerifier.kt
@@ -17,12 +17,14 @@ import org.apache.commons.lang3.StringUtils
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_2_7_2
 import org.codice.compliance.SAMLCore_2_7_3
+import org.codice.compliance.SAMLCore_2_7_3_1
 import org.codice.compliance.SAMLCore_2_7_3_1_1
 import org.codice.compliance.SAMLCore_2_7_3_2_a
 import org.codice.compliance.SAMLCore_2_7_4_a
 import org.codice.compliance.allChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon
+import org.codice.compliance.utils.TestCommon.Companion.SAML_NAMESPACE
 import org.w3c.dom.Node
 
 internal class StatementVerifier(val node: Node) {
@@ -84,8 +86,10 @@ internal class StatementVerifier(val node: Node) {
 
             if (encryptedData
                             .filter { it.attributes.getNamedItem(TYPE) != null }
-                            .any { it.attributes.getNamedItem(TYPE).textContent !=
-                                    TestCommon.ELEMENT })
+                            .any {
+                                it.attributes.getNamedItem(TYPE).textContent !=
+                                        TestCommon.ELEMENT
+                            })
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_7_3_2_a,
                         property = TYPE,
                         actual = it.attributes.getNamedItem(TYPE).textContent,
@@ -104,6 +108,7 @@ internal class StatementVerifier(val node: Node) {
                         parent = ATTRIBUTE,
                         node = node)
 
+            val remainingAttributes = mutableListOf<Node>()
             val nameAttribute = it.attributes.getNamedItem("Name")
             val nameFormatAttribute = it.attributes.getNamedItem("NameFormat")
             val friendlyNameAttr = it.attributes.getNamedItem("FriendlyName")
@@ -113,7 +118,28 @@ internal class StatementVerifier(val node: Node) {
                     || (friendlyNameAttr != null && friendlyNameAttr.textContent == null)) {
                 verifyAttributeValue(it)
             }
+
+            for (i in it.attributes.length - 1 downTo 0) {
+                val attribute = it.attributes.item(i)
+                if (isNullOrSamlNamespace(attribute) && isUnknownSamlAttribute(attribute)) {
+                    throw SAMLComplianceException.create(SAMLCore_2_7_3_1,
+                            message = "An unknown attribute element was found on the <Attribute> " +
+                                    "node element.",
+                            node = attribute)
+                }
+            }
         }
+    }
+
+    private fun isNullOrSamlNamespace(attribute: Node): Boolean {
+        return with(attribute) {
+            namespaceURI == null || namespaceURI == SAML_NAMESPACE
+        }
+    }
+
+    private fun isUnknownSamlAttribute(attribute: Node): Boolean {
+        return !listOf("Name", "NameFormat", "FriendlyName").contains(
+                attribute.localName)
     }
 
     private fun verifyAttributeValue(it: Node) {

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/SubjectVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/SubjectVerifier.kt
@@ -14,13 +14,14 @@
 package org.codice.compliance.verification.core.internal
 
 import org.codice.compliance.SAMLComplianceException
-import org.codice.compliance.SAMLCore_2_4_1_2_c
 import org.codice.compliance.SAMLCore_2_4_1_3
 import org.codice.compliance.SAMLCore_2_5_1_2
 import org.codice.compliance.XMLSignature_4_5
 import org.codice.compliance.allChildren
+import org.codice.compliance.attributeList
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon
+import org.codice.compliance.verification.core.CoreVerifier
 import org.w3c.dom.Node
 import java.time.Instant
 
@@ -73,27 +74,9 @@ internal class SubjectVerifier(val node: Node) {
                         message = "Multiple Keys found within the KeyInfo element.",
                         node = node)
 
-            for (i in it.attributes.length - 1 downTo 0) {
-                val attribute = it.attributes.item(i)
-                if (isNullOrSamlNamespace(attribute) && isUnknownSamlAttribute(attribute)) {
-                    throw SAMLComplianceException.create(SAMLCore_2_4_1_2_c,
-                            message = "An unknown attribute element was found on the " +
-                                    "<SubjectConfirmationData> node element.",
-                            node = attribute)
-                }
-            }
+            CoreVerifier.verifySamlExtensions(it.attributeList(),
+                    expectedSamlNames = listOf("NotBefore", "NotOnOrAfter", "Recipient",
+                            "InResponseTo", "Address"))
         }
-    }
-
-    private fun isNullOrSamlNamespace(attribute: Node): Boolean {
-        return with(attribute) {
-            namespaceURI == null || namespaceURI == TestCommon.SAML_NAMESPACE
-        }
-    }
-
-    private fun isUnknownSamlAttribute(attribute: Node): Boolean {
-        return !listOf("NotBefore", "NotOnOrAfter", "Recipient", "InResponseTo",
-                "Address").contains(
-                attribute.localName)
     }
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/SubjectVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/internal/SubjectVerifier.kt
@@ -14,6 +14,7 @@
 package org.codice.compliance.verification.core.internal
 
 import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.SAMLCore_2_4_1_2_c
 import org.codice.compliance.SAMLCore_2_4_1_3
 import org.codice.compliance.SAMLCore_2_5_1_2
 import org.codice.compliance.XMLSignature_4_5
@@ -71,6 +72,28 @@ internal class SubjectVerifier(val node: Node) {
                 throw SAMLComplianceException.create(SAMLCore_2_4_1_3, XMLSignature_4_5,
                         message = "Multiple Keys found within the KeyInfo element.",
                         node = node)
+
+            for (i in it.attributes.length - 1 downTo 0) {
+                val attribute = it.attributes.item(i)
+                if (isNullOrSamlNamespace(attribute) && isUnknownSamlAttribute(attribute)) {
+                    throw SAMLComplianceException.create(SAMLCore_2_4_1_2_c,
+                            message = "An unknown attribute element was found on the " +
+                                    "<SubjectConfirmationData> node element.",
+                            node = attribute)
+                }
+            }
         }
+    }
+
+    private fun isNullOrSamlNamespace(attribute: Node): Boolean {
+        return with(attribute) {
+            namespaceURI == null || namespaceURI == TestCommon.SAML_NAMESPACE
+        }
+    }
+
+    private fun isUnknownSamlAttribute(attribute: Node): Boolean {
+        return !listOf("NotBefore", "NotOnOrAfter", "Recipient", "InResponseTo",
+                "Address").contains(
+                attribute.localName)
     }
 }

--- a/ctk/idp/coverage/Core.md
+++ b/ctk/idp/coverage/Core.md
@@ -34,7 +34,7 @@ Unmarked sections need attention
 	2.4 Subjects
 		2.4.1 Element <Subject>
 +			2.4.1.1 Element <SubjectConfirmation>
-			2.4.1.2 Element <SubjectConfirmationData>
++			2.4.1.2 Element <SubjectConfirmationData>
 			2.4.1.3 Complex Type KeyInfoConfirmationDataType
 -			2.4.1.4 Example of a Key-Confirmed <Subject>
 	2.5 Conditions
@@ -53,7 +53,7 @@ Unmarked sections need attention
 -			2.7.2.1 Element <SubjectLocality>
 -			2.7.2.2 Element <AuthnContext>
 		2.7.3 Element <AttributeStatement>
-			2.7.3.1 Element <Attribute>
++			2.7.3.1 Element <Attribute>
 +				2.7.3.1.1 Element <AttributeValue>
 			2.7.3.2 Element <EncryptedAttribute>
 		2.7.4 Element <AuthzDecisionStatement>

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -116,11 +116,11 @@ fun Log.debugWithSupplier(message: () -> String) {
  * @param name - Name of Assertions.children
  * @return list of Assertions.children matching the name provided
  */
-fun Node.children(name: String): List<Node> {
+fun Node.children(name: String = "default"): List<Node> {
     val childNodes = mutableListOf<Node>()
     for (i in (this.childNodes.length - 1) downTo 0) {
         this.childNodes.item(i).apply {
-            if (localName == name) childNodes.add(this)
+            if (localName == name || name == "default") childNodes.add(this)
         }
     }
     return childNodes
@@ -142,6 +142,16 @@ fun Node.allChildren(name: String): List<Node> {
         nodes.addAll(child.allChildren(name)); i -= 1
     }
     return nodes
+}
+
+fun Node.attributeList(): List<Node> {
+    val attributesList = mutableListOf<Node>()
+    this.attributes.let {
+        for (i in it.length - 1 downTo 0) {
+            attributesList.add(it.item(i))
+        }
+    }
+    return attributesList
 }
 
 fun Node.prettyPrintXml(): String {

--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -76,6 +76,7 @@ object SAMLProfiles_4_1_4_5 : SAMLProfileRefMessage()
 // CORE
 //-----------------
 object SAMLCore_Schema : SAMLCoreRefMessage()
+object SAMLCore_SamlExtensions : SAMLCoreRefMessage()
 
 object SAMLCore_1_3_1_a : SAMLCoreRefMessage()
 
@@ -93,7 +94,6 @@ object SAMLCore_2_3_3_c : SAMLCoreRefMessage()
 object SAMLCore_2_3_4_a : SAMLCoreRefMessage()
 
 object SAMLCore_2_4_1_2_b : SAMLCoreRefMessage()
-object SAMLCore_2_4_1_2_c : SAMLCoreRefMessage()
 
 object SAMLCore_2_4_1_3 : SAMLCoreRefMessage()
 
@@ -107,7 +107,6 @@ object SAMLCore_2_5_1_6_b : SAMLCoreRefMessage()
 
 object SAMLCore_2_7_2 : SAMLCoreRefMessage()
 object SAMLCore_2_7_3 : SAMLCoreRefMessage()
-object SAMLCore_2_7_3_1 : SAMLCoreRefMessage()
 object SAMLCore_2_7_3_1_1 : SAMLCoreRefMessage()
 object SAMLCore_2_7_3_2_a : SAMLCoreRefMessage()
 

--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -18,7 +18,8 @@ package org.codice.compliance
 import java.net.URI
 import java.util.ResourceBundle
 
-sealed class SAMLSpecRefMessage(docRefKey: String, docUriKey: String) {
+sealed class SAMLSpecRefMessage(docRefKey: String,
+                                docUriKey: String) {
     private val docRef: String
     private val docUri: URI
 
@@ -92,6 +93,8 @@ object SAMLCore_2_3_3_c : SAMLCoreRefMessage()
 object SAMLCore_2_3_4_a : SAMLCoreRefMessage()
 
 object SAMLCore_2_4_1_2_b : SAMLCoreRefMessage()
+object SAMLCore_2_4_1_2_c : SAMLCoreRefMessage()
+
 object SAMLCore_2_4_1_3 : SAMLCoreRefMessage()
 
 object SAMLCore_2_5_1_a : SAMLCoreRefMessage()
@@ -104,6 +107,7 @@ object SAMLCore_2_5_1_6_b : SAMLCoreRefMessage()
 
 object SAMLCore_2_7_2 : SAMLCoreRefMessage()
 object SAMLCore_2_7_3 : SAMLCoreRefMessage()
+object SAMLCore_2_7_3_1 : SAMLCoreRefMessage()
 object SAMLCore_2_7_3_1_1 : SAMLCoreRefMessage()
 object SAMLCore_2_7_3_2_a : SAMLCoreRefMessage()
 

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -118,6 +118,11 @@ SAMLCore_2_3_4_a=The Type attribute [for an EncryptedData] SHOULD be present and
 SAMLCore_2_4_1_2_b=If both attributes are present, the value for NotBefore MUST be less than \
   (earlier than) the value for NotOnOrAfter.
 
+SAMLCore_2_4_1_2_c=SAML extensions MUST NOT add local (non-namespace-qualified) XML attributes or \
+  XML attributes qualified by a SAML-defined namespace to the AttributeType complex type or a \
+  derivation of it; such attributes are reserved for future maintenance and enhancement of SAML \
+  itself.
+
 SAMLCore_2_4_1_3=Note that in accordance with [XMLSig], each <ds:KeyInfo> element MUST identify a \
   single cryptographic key.
 
@@ -146,6 +151,11 @@ SAMLCore_2_5_1_6_b=A SAML authority MUST NOT include more than one <ProxyRestric
 SAMLCore_2_7_2=Assertions containing <AuthnStatement> elements MUST contain a <Subject> element.
 
 SAMLCore_2_7_3=Assertions containing <AttributeStatement> elements MUST contain a <Subject> element.
+
+SAMLCore_2_7_3_1=SAML extensions MUST NOT add local (non-namespace-qualified) XML attributes or \
+  XML attributes qualified by a SAML-defined namespace to the AttributeType complex type or a \
+  derivation of it; such attributes are reserved for future maintenance and enhancement of SAML \
+  itself.
 
 SAMLCore_2_7_3_1_1=If a SAML attribute includes a 'null' value, the corresponding <AttributeValue> \
   element MUST be empty and MUST contain the reserved xsi:nil XML attribute with a value of 'true' \

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -81,6 +81,9 @@ SAMLCore.uri=https://www.oasis-open.org/committees/download.php/56777/sstc-saml-
 SAMLCore_Schema=All SAML messages must follow the core SAML schemas. See the core specification \
   for detailed information about SAML message structure.
 
+SAMLCore_SamlExtensions=SAML extensions MUST be namespace-qualified in a non-SAML-defined |\
+  namespace. This statement can be found in sections 2.4.1.2, 2.7.3.1, 3.2.1, 3.2.2.
+
 SAMLCore_1_3_1_a=Unless otherwise noted in this specification or particular profiles, all strings \
   in SAML messages MUST consist of at least one non-whitespace character (whitespace is defined in \
   the XML Recommendation [XML] Section 2.3).
@@ -118,11 +121,6 @@ SAMLCore_2_3_4_a=The Type attribute [for an EncryptedData] SHOULD be present and
 SAMLCore_2_4_1_2_b=If both attributes are present, the value for NotBefore MUST be less than \
   (earlier than) the value for NotOnOrAfter.
 
-SAMLCore_2_4_1_2_c=SAML extensions MUST NOT add local (non-namespace-qualified) XML attributes or \
-  XML attributes qualified by a SAML-defined namespace to the AttributeType complex type or a \
-  derivation of it; such attributes are reserved for future maintenance and enhancement of SAML \
-  itself.
-
 SAMLCore_2_4_1_3=Note that in accordance with [XMLSig], each <ds:KeyInfo> element MUST identify a \
   single cryptographic key.
 
@@ -151,11 +149,6 @@ SAMLCore_2_5_1_6_b=A SAML authority MUST NOT include more than one <ProxyRestric
 SAMLCore_2_7_2=Assertions containing <AuthnStatement> elements MUST contain a <Subject> element.
 
 SAMLCore_2_7_3=Assertions containing <AttributeStatement> elements MUST contain a <Subject> element.
-
-SAMLCore_2_7_3_1=SAML extensions MUST NOT add local (non-namespace-qualified) XML attributes or \
-  XML attributes qualified by a SAML-defined namespace to the AttributeType complex type or a \
-  derivation of it; such attributes are reserved for future maintenance and enhancement of SAML \
-  itself.
 
 SAMLCore_2_7_3_1_1=If a SAML attribute includes a 'null' value, the corresponding <AttributeValue> \
   element MUST be empty and MUST contain the reserved xsi:nil XML attribute with a value of 'true' \


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Verify for SAML extensions for both `<Attribute>` and `<SubjectConfirmationData>` elements. Here's the spec snippet which is identical in both:
```
SAML extensions MUST NOT add local (non-namespace-qualified) XML attributes or XML 
attributes qualified by a SAML-defined namespace to the SubjectConfirmationDataType 
complex type or a derivation of it; such attributes are reserved for future maintenance 
and enhancement of SAML itself.
```
#### Checklist:
- [x] SAML Spec Table of Contents documentation updated
☝️ Had that updated *before* I got the PR up BTW! 😄 