### PR TITLE
MAINT - Pull Node extension functions into their own class and adds new ones

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
@@ -27,6 +27,7 @@ import org.codice.compliance.SAMLBindings_3_5_4_d2
 import org.codice.compliance.SAMLBindings_3_5_5_2_a
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLProfiles_4_1_4_5
+import org.codice.compliance.attributeNode
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
 import org.codice.compliance.debugPrettyPrintXml
@@ -227,7 +228,7 @@ class PostBindingVerifier(private val response: IdpPostResponseDecorator) : Bind
      * 3.5.5.2 Security Considerations
      */
     private fun verifyPostDestination() {
-        val destination = response.responseDom.attributes?.getNamedItem("Destination")?.nodeValue
+        val destination = response.responseDom.attributeNode("Destination")?.nodeValue
         val signatures = response.responseDom.recursiveChildren("Signature")
 
         if (signatures.isNotEmpty() && destination != acsUrl[HTTP_POST]) {

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
@@ -33,6 +33,7 @@ import org.codice.compliance.SAMLBindings_3_4_4_a
 import org.codice.compliance.SAMLBindings_3_4_6_a
 import org.codice.compliance.SAMLBindings_3_5_5_2_a
 import org.codice.compliance.SAMLComplianceException
+import org.codice.compliance.attributeNode
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
 import org.codice.compliance.debugPrettyPrintXml
@@ -413,7 +414,7 @@ class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator
      * 3.4.5.2 Security Considerations
      */
     private fun verifyRedirectDestination() {
-        val destination = response.responseDom.attributes?.getNamedItem("Destination")?.nodeValue
+        val destination = response.responseDom.attributeNode("Destination")?.nodeValue
         val signatures = response.responseDom.recursiveChildren("Signature")
 
         if (signatures.isNotEmpty() && destination != acsUrl[HTTP_REDIRECT]) {

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
@@ -20,6 +20,7 @@ import org.codice.compliance.SAMLCore_1_3_2_a
 import org.codice.compliance.SAMLCore_1_3_3
 import org.codice.compliance.SAMLCore_1_3_4
 import org.codice.compliance.SAMLSpecRefMessage
+import org.codice.compliance.attributeTextNS
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.utils.TestCommon.Companion.XSI
 import org.w3c.dom.Node
@@ -32,7 +33,7 @@ class CommonDataTypeVerifier {
         /** 1.3 Common Data Types **/
         fun verifyCommonDataType(samlDom: Node) {
             samlDom.recursiveChildren().forEach {
-                it.attributes?.getNamedItemNS(XSI, "type")?.textContent?.let { type ->
+                it.attributeTextNS(XSI, "type")?.let { type ->
                     when {
                         type.contains("string") -> verifyStringValues(it)
                         type.contains("anyURI") -> verifyUriValues(it)
@@ -59,10 +60,10 @@ class CommonDataTypeVerifier {
         }
 
         /** 1.3.2 URI Values **/
-        fun verifyUriValues(node: Node, errorCode: SAMLSpecRefMessage? = null) {
-            if (StringUtils.isBlank(node.textContent)
+        fun verifyUriValues(node: Node?, errorCode: SAMLSpecRefMessage? = null) {
+            if (node == null || StringUtils.isBlank(node.textContent)
                     || !URI.create(node.textContent).isAbsolute) {
-                val errorMessage = "The URI value of ${node.textContent} is invalid."
+                val errorMessage = "The URI value of [${node?.textContent}] is invalid."
                 if (errorCode != null) throw SAMLComplianceException.create(errorCode,
                         SAMLCore_1_3_2_a,
                         message = errorMessage)
@@ -72,9 +73,9 @@ class CommonDataTypeVerifier {
         }
 
         /** 1.3.3 Time Values **/
-        fun verifyDateTimeValues(node: Node, errorCode: SAMLSpecRefMessage? = null) {
-            if (!node.textContent.endsWith("Z")) {
-                val errorMessage = "The time date value of ${node.textContent} is not in UTC."
+        fun verifyDateTimeValues(node: Node?, errorCode: SAMLSpecRefMessage? = null) {
+            if (node == null || !node.textContent.endsWith("Z")) {
+                val errorMessage = "The time date value of [${node?.textContent}] is not in UTC."
                 if (errorCode != null) throw SAMLComplianceException.create(errorCode,
                         SAMLCore_1_3_3,
                         message = errorMessage)
@@ -84,9 +85,9 @@ class CommonDataTypeVerifier {
         }
 
         /** 1.3.4 ID and ID Reference Values **/
-        fun verifyIdValues(node: Node, errorCode: SAMLSpecRefMessage? = null) {
-            if (ids.contains(node.textContent)) {
-                val errorMessage = "The ID value of ${node.textContent} is not unique."
+        fun verifyIdValues(node: Node?, errorCode: SAMLSpecRefMessage? = null) {
+            if (node == null || ids.contains(node.textContent)) {
+                val errorMessage = "The ID value of [${node?.textContent}] is not unique."
                 if (errorCode != null) throw SAMLComplianceException.create(errorCode,
                         SAMLCore_1_3_4,
                         message = errorMessage)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -18,6 +18,8 @@ import org.codice.compliance.SAMLCoreRefMessage
 import org.codice.compliance.SAMLCore_3_2_1_d
 import org.codice.compliance.SAMLCore_SamlExtensions
 import org.codice.compliance.SAMLSpecRefMessage
+import org.codice.compliance.attributeNode
+import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.TestCommon.Companion.REQUESTER
@@ -79,11 +81,11 @@ class CoreVerifier(val node: Node) {
          * that the value of NotBefore is less than the value for NotOnOrAfter.
          */
         internal fun validateTimeWindow(node: Node, samlCode: SAMLCoreRefMessage) {
-            val notBefore = node.attributes?.getNamedItem("NotBefore")?.apply {
+            val notBefore = node.attributeNode("NotBefore")?.apply {
                 CommonDataTypeVerifier.verifyDateTimeValues(this)
             }
 
-            val notOnOrAfter = node.attributes?.getNamedItem("NotOnOrAfter")?.apply {
+            val notOnOrAfter = node.attributeNode("NotOnOrAfter")?.apply {
                 CommonDataTypeVerifier.verifyDateTimeValues(this)
             }
 
@@ -126,7 +128,8 @@ class CoreVerifier(val node: Node) {
                     expected = "<Status>",
                     node = node)
         status[0].children("StatusCode").forEach {
-            val code = it.attributes.getNamedItem("Value").textContent
+            val code = it.attributeText("Value")
+
             if (code != expectedStatusCode) {
                 var exceptions = arrayOf(samlErrorCode)
                 if (expectedStatusCode == REQUESTER)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
@@ -19,6 +19,7 @@ import org.codice.compliance.SAMLCore_2_3_4_a
 import org.codice.compliance.SAMLCore_2_7_3_2_a
 import org.codice.compliance.SAMLCore_6_1_a
 import org.codice.compliance.SAMLCore_6_1_b
+import org.codice.compliance.attributeText
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon
@@ -66,8 +67,7 @@ class EncryptionVerifier {
     private fun verifyEncryptedElement(encryptedElement: Node) {
         if (encryptedElement.children("EncryptedData")
                         .first() // guaranteed to have an EncryptedData child by schema validation
-                        .attributes?.getNamedItem("Type")
-                        ?.textContent != TestCommon.ELEMENT)
+                        .attributeText("Type") != TestCommon.ELEMENT)
             throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_6_1_b,
                     when (encryptedElement.localName) {
                         "EncryptedID" -> SAMLCore_2_2_4_a
@@ -76,8 +76,7 @@ class EncryptionVerifier {
                         else -> throw UnknownError("Unknown ${encryptedElement.localName} type.")
                     },
                     property = TestCommon.TYPE,
-                    actual = encryptedElement.attributes
-                            ?.getNamedItem(TestCommon.TYPE)?.textContent,
+                    actual = encryptedElement.attributeText(TestCommon.TYPE),
                     expected = TestCommon.ELEMENT,
                     node = encryptedElement)
     }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
@@ -17,6 +17,8 @@ import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_8_1_2
 import org.codice.compliance.SAMLCore_8_2_2
 import org.codice.compliance.SAMLCore_8_2_3
+import org.codice.compliance.attributeNode
+import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
 import org.w3c.dom.DOMException
@@ -58,7 +60,7 @@ internal class SamlDefinedIdentifiersVerifier(val node: Node) {
 
     private fun createActionList(query: Node): List<String> {
         return query.children("Action")
-                .filter { it.attributes.getNamedItem("Namespace").nodeValue in RWEDC_URI_SET }
+                .filter { it.attributeNode("Namespace")?.nodeValue in RWEDC_URI_SET }
                 .map { it.nodeValue }
                 .toList()
     }
@@ -80,13 +82,13 @@ internal class SamlDefinedIdentifiersVerifier(val node: Node) {
     /** 8.2 URI/Basic name attribute formats */
     private fun verifyAttributeNameFormatIdentifiers() {
         node.recursiveChildren("Attribute").forEach {
-            val name = it.attributes.getNamedItem("Name")
-            val nameFormat = it.attributes?.getNamedItem("NameFormat")
-            if (name == null || nameFormat?.textContent == null) {
+            val name = it.attributeNode("Name")
+            val nameFormatText = it.attributeText("NameFormat")
+            if (name == null || nameFormatText == null) {
                 return
             }
 
-            when (nameFormat.textContent) {
+            when (nameFormatText) {
                 ATTRIBUTE_NAME_FORMAT_URI -> {
                     try {
                         URI(name.textContent)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SignatureSyntaxAndProcessingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SignatureSyntaxAndProcessingVerifier.kt
@@ -17,6 +17,7 @@ import org.apache.cxf.rs.security.saml.sso.SSOConstants
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_5_4_2_b
 import org.codice.compliance.SAMLCore_5_4_2_b1
+import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
 import org.w3c.dom.Node
@@ -38,12 +39,12 @@ class SignatureSyntaxAndProcessingVerifier(private val node: Node) {
                                 "${references.size} found.",
                         node = node)
 
-            val uriValue = references[0].attributes.getNamedItem("URI")?.textContent
+            val uriValue = references[0].attributeText("URI")
                     ?: throw SAMLComplianceException.create(SAMLCore_5_4_2_b1,
                             message = "URI attribute not found.",
                             node = node)
 
-            val formattedId = "#${it.parentNode.attributes?.getNamedItem("ID")?.textContent}"
+            val formattedId = "#${it.parentNode.attributeText("ID")}"
             if (uriValue != formattedId)
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_5_4_2_b,
                         property = "URI",

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/AssertionsVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/AssertionsVerifier.kt
@@ -19,6 +19,8 @@ import org.codice.compliance.SAMLCore_2_2_3_b
 import org.codice.compliance.SAMLCore_2_3_3_a
 import org.codice.compliance.SAMLCore_2_3_3_b
 import org.codice.compliance.SAMLCore_2_3_3_c
+import org.codice.compliance.attributeNode
+import org.codice.compliance.attributeNodeNS
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon
@@ -48,22 +50,22 @@ internal class AssertionsVerifier(val node: Node) {
     @Suppress("ComplexCondition")
     private fun verifyAssertion() {
         node.recursiveChildren("Assertion").forEach {
-            val version = it.attributes.getNamedItem(VERSION)
-            if (version.textContent != SAML_VERSION)
+            val version = it.attributeNode(VERSION)
+            if (version?.textContent != SAML_VERSION)
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_3_3_a,
                         property = VERSION,
-                        actual = it.attributes.getNamedItem(VERSION).textContent,
+                        actual = version?.textContent,
                         expected = SAML_VERSION,
                         node = node)
 
             CommonDataTypeVerifier.verifyStringValues(version)
-            CommonDataTypeVerifier.verifyIdValues(it.attributes.getNamedItem("ID"),
+            CommonDataTypeVerifier.verifyIdValues(it.attributeNode("ID"),
                     SAMLCore_2_3_3_b)
-            CommonDataTypeVerifier.verifyDateTimeValues(it.attributes.getNamedItem("IssueInstant"),
+            CommonDataTypeVerifier.verifyDateTimeValues(it.attributeNode("IssueInstant"),
                     SAMLCore_2_3_3_c)
 
             val statements = it.children("Statement")
-            if (statements.any { it.attributes?.getNamedItemNS(TestCommon.XSI, "type") == null })
+            if (statements.any { it.attributeNodeNS(TestCommon.XSI, "type") == null })
                 throw SAMLComplianceException.create(SAMLCore_2_2_3_a,
                         message = "Statement element found without a type.",
                         node = node)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/ConditionsVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/ConditionsVerifier.kt
@@ -21,6 +21,7 @@ import org.codice.compliance.SAMLCore_2_5_1_6_b
 import org.codice.compliance.SAMLCore_2_5_1_a
 import org.codice.compliance.SAMLCore_2_5_1_b
 import org.codice.compliance.SAMLCore_2_5_1_c
+import org.codice.compliance.attributeNodeNS
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon
@@ -52,7 +53,7 @@ internal class ConditionsVerifier(val node: Node) {
         validateTimeWindow(conditionsElement, SAMLCore_2_5_1_2)
 
         if (conditionsElement.children("Condition")
-                        .any { it.attributes?.getNamedItemNS(TestCommon.XSI, "type") == null })
+                        .any { it.attributeNodeNS(TestCommon.XSI, "type") == null })
             throw SAMLComplianceException.create(SAMLCore_2_5_1_a,
                     message = "Condition found without a type.",
                     node = node)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/NameIdentifierVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/NameIdentifierVerifier.kt
@@ -13,6 +13,7 @@
  */
 package org.codice.compliance.verification.core.assertions
 
+import org.codice.compliance.attributeNode
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.w3c.dom.Node
@@ -23,11 +24,11 @@ internal class NameIdentifierVerifier(val node: Node) {
         /** 2.2.1 Element <BaseID> */
         private fun verifyIdNameQualifiers(node: Node) {
             node.recursiveChildren("BaseID").forEach {
-                it.attributes?.getNamedItem("NameQualifier")?.let {
+                it.attributeNode("NameQualifier")?.let {
                     CommonDataTypeVerifier.verifyStringValues(it)
                 }
 
-                it.attributes?.getNamedItem("SPNameQualifier")?.let {
+                it.attributeNode("SPNameQualifier")?.let {
                     CommonDataTypeVerifier.verifyStringValues(it)
                 }
             }
@@ -36,11 +37,11 @@ internal class NameIdentifierVerifier(val node: Node) {
         /** 2.2.2 Complex Type NameIDType */
         fun verifyNameIDType(node: Node) {
             verifyIdNameQualifiers(node)
-            node.attributes?.getNamedItem("Format")?.let {
+            node.attributeNode("Format")?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
 
-            node.attributes?.getNamedItem("SPProvidedID")?.let {
+            node.attributeNode("SPProvidedID")?.let {
                 CommonDataTypeVerifier.verifyStringValues(it)
             }
         }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/StatementVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/StatementVerifier.kt
@@ -18,6 +18,7 @@ import org.codice.compliance.SAMLCore_2_7_2
 import org.codice.compliance.SAMLCore_2_7_3
 import org.codice.compliance.SAMLCore_2_7_4_a
 import org.codice.compliance.attributeList
+import org.codice.compliance.attributeNode
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
@@ -44,13 +45,13 @@ internal class StatementVerifier(val node: Node) {
     /** 2.7.2 Element <AuthnStatement> **/
     private fun verifyAuthnStatement() {
         node.recursiveChildren("AuthnStatement").forEach {
-            CommonDataTypeVerifier.verifyDateTimeValues(it.attributes.getNamedItem("AuthnInstant"))
+            CommonDataTypeVerifier.verifyDateTimeValues(it.attributeNode("AuthnInstant"))
 
-            it.attributes?.getNamedItem("SessionIndex")?.let {
+            it.attributeNode("SessionIndex")?.let {
                 CommonDataTypeVerifier.verifyStringValues(it)
             }
 
-            it.attributes?.getNamedItem("SessionNotOnOrAfter")?.let {
+            it.attributeNode("SessionNotOnOrAfter")?.let {
                 CommonDataTypeVerifier.verifyDateTimeValues(it)
             }
         }
@@ -66,11 +67,11 @@ internal class StatementVerifier(val node: Node) {
     /** 2.7.2.1 Element <SubjectLocality> **/
     private fun verifySubjectLocality() {
         node.recursiveChildren("SubjectLocality").forEach {
-            it.attributes?.getNamedItem("Address")?.let {
+            it.attributeNode("Address")?.let {
                 CommonDataTypeVerifier.verifyStringValues(it)
             }
 
-            it.attributes?.getNamedItem("DNSName")?.let {
+            it.attributeNode("DNSName")?.let {
                 CommonDataTypeVerifier.verifyStringValues(it)
             }
         }
@@ -79,16 +80,16 @@ internal class StatementVerifier(val node: Node) {
     /** 2.7.2.2 Element <AuthnContext> **/
     private fun verifyAuthnContext() {
         node.recursiveChildren("AuthnContext").forEach {
-            it.attributes?.getNamedItem("AuthnContextClassRef")?.let {
+            it.attributeNode("AuthnContextClassRef")?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
-            it.attributes?.getNamedItem("AuthnContextDeclRef")?.let {
+            it.attributeNode("AuthnContextDeclRef")?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
-            it.attributes?.getNamedItem("AuthnContextDecl")?.let {
+            it.attributeNode("AuthnContextDecl")?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
-            it.attributes?.getNamedItem("AuthenticatingAuthority")?.let {
+            it.attributeNode("AuthenticatingAuthority")?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
         }
@@ -109,11 +110,11 @@ internal class StatementVerifier(val node: Node) {
         node.recursiveChildren("Attribute").forEach {
             CommonDataTypeVerifier.verifyStringValues(it.attributes.getNamedItem("Name"))
 
-            it.attributes?.getNamedItem("NameFormat")?.let {
+            it.attributeNode("NameFormat")?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
 
-            it.attributes?.getNamedItem("FriendlyName")?.let {
+            it.attributeNode("FriendlyName")?.let {
                 CommonDataTypeVerifier.verifyStringValues(it)
             }
 
@@ -134,14 +135,14 @@ internal class StatementVerifier(val node: Node) {
                     node = node)
 
         node.recursiveChildren("AuthzDecisionStatement").forEach {
-            CommonDataTypeVerifier.verifyUriValues(it.attributes.getNamedItem("Resource"))
+            CommonDataTypeVerifier.verifyUriValues(it.attributeNode("Resource"))
         }
     }
 
     /** 2.7.4.2 Element <Action> **/
     private fun verifyAction() {
         node.recursiveChildren("Action").forEach {
-            CommonDataTypeVerifier.verifyUriValues(it.attributes.getNamedItem("Namespace"))
+            CommonDataTypeVerifier.verifyUriValues(it.attributeNode("Namespace"))
         }
     }
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/SubjectVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/SubjectVerifier.kt
@@ -15,6 +15,7 @@ package org.codice.compliance.verification.core.assertions
 
 import org.codice.compliance.SAMLCore_2_4_1_2_a
 import org.codice.compliance.attributeList
+import org.codice.compliance.attributeNode
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.codice.compliance.verification.core.CoreVerifier
@@ -34,7 +35,7 @@ internal class SubjectVerifier(val node: Node) {
         node.recursiveChildren("SubjectConfirmation")
                 .forEach {
                     CommonDataTypeVerifier
-                            .verifyUriValues(it.attributes.getNamedItem("Method"))
+                            .verifyUriValues(it.attributeNode("Method"))
                 }
     }
 
@@ -43,11 +44,11 @@ internal class SubjectVerifier(val node: Node) {
         node.recursiveChildren("SubjectConfirmationData").forEach {
             validateTimeWindow(it, SAMLCore_2_4_1_2_a)
 
-            it.attributes?.getNamedItem("Recipient")?.let {
+            it.attributeNode("Recipient")?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
 
-            it.attributes?.getNamedItem("Address")?.let {
+            it.attributeNode("Address")?.let {
                 CommonDataTypeVerifier.verifyStringValues(it)
             }
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
@@ -19,6 +19,8 @@ import org.codice.compliance.SAMLProfiles_3_1_b
 import org.codice.compliance.SAMLProfiles_3_1_c
 import org.codice.compliance.SAMLProfiles_4_1_4_2_l
 import org.codice.compliance.SAMLSpecRefMessage
+import org.codice.compliance.attributeNodeNS
+import org.codice.compliance.attributeText
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
 import org.codice.compliance.utils.TestCommon.Companion.HOLDER_OF_KEY_URI
@@ -59,11 +61,11 @@ class ProfilesVerifier(private val node: Node) {
      */
     private fun verifyHolderOfKey() {
         val subjectConfirmationDataList = node.recursiveChildren("SubjectConfirmation")
-                .filter { it.attributes.getNamedItem("Method").textContent == HOLDER_OF_KEY_URI }
+                .filter { it.attributeText("Method") == HOLDER_OF_KEY_URI }
                 .flatMap { it.children("SubjectConfirmationData") }
 
         subjectConfirmationDataList.forEach {
-            val type = it.attributes?.getNamedItemNS(XSI, "type")
+            val type = it.attributeNodeNS(XSI, "type")
             if (type != null && !type.textContent.contains("KeyInfoConfirmationDataType"))
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLProfiles_3_1_b,
                         property = "type",

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
@@ -25,6 +25,8 @@ import org.codice.compliance.SAMLProfiles_4_1_4_2_h
 import org.codice.compliance.SAMLProfiles_4_1_4_2_i
 import org.codice.compliance.SAMLProfiles_4_1_4_2_j
 import org.codice.compliance.SAMLProfiles_4_1_4_2_k
+import org.codice.compliance.attributeNode
+import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.saml.plugin.IdpRedirectResponse
 import org.codice.compliance.utils.TestCommon.Companion.BEARER
@@ -85,7 +87,7 @@ class SingleSignOnProfileVerifier(private val response: Node,
                                 "issuing IdP.",
                         node = response)
 
-            val issuerFormat = issuer.attributes?.getNamedItem("Format")?.textContent
+            val issuerFormat = issuer.attributeText("Format")
             if (issuerFormat != null &&
                     issuerFormat != ENTITY)
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLProfiles_4_1_4_2_c,
@@ -117,7 +119,7 @@ class SingleSignOnProfileVerifier(private val response: Node,
                         .flatMap { it.children(SUBJECT) }
                         .filter { it.children("SubjectConfirmation").isNotEmpty() }
                         .flatMap { it.children("SubjectConfirmation") }
-                        .filter { it.attributes.getNamedItem("Method").textContent == BEARER }
+                        .filter { it.attributeText("Method") == BEARER }
                         .map { it to it.parentNode.parentNode }
                         .unzip()
 
@@ -138,11 +140,11 @@ class SingleSignOnProfileVerifier(private val response: Node,
                         .filter { it.children("SubjectConfirmationData").isNotEmpty() }
                         .flatMap { it.children("SubjectConfirmationData") }
                         .none {
-                            it.attributes?.getNamedItem("Recipient")?.textContent == acsUrl &&
-                                    it.attributes?.getNamedItem("NotOnOrAfter") != null &&
-                                    it.attributes?.getNamedItem("NotBefore") == null &&
-                                    it.attributes?.getNamedItem("InResponseTo")?.textContent ==
-                                    ID }) {
+                            it.attributeText("Recipient") == acsUrl &&
+                                    it.attributeNode("NotOnOrAfter") != null &&
+                                    it.attributeNode("NotBefore") == null &&
+                                    it.attributeText("InResponseTo") == ID
+                        }) {
             throw SAMLComplianceException.create(SAMLProfiles_4_1_4_2_h,
                     message = "There were no bearer SubjectConfirmation elements that matched " +
                             "the criteria below.",
@@ -164,7 +166,7 @@ class SingleSignOnProfileVerifier(private val response: Node,
 
         if (bearerAssertions.filter { it.children(AUTHN_STATEMENT).isNotEmpty() }
                         .flatMap { it.children(AUTHN_STATEMENT) }
-                        .any { it.attributes?.getNamedItem("SessionIndex") == null })
+                        .any { it.attributeNode("SessionIndex") == null })
             throw SAMLComplianceException.create(SAMLProfiles_4_1_4_2_j,
                     message = "Single Logout support found in IdP metadata, but no " +
                             "SessionIndex was found.",

--- a/library/src/main/kotlin/org/codice/compliance/NodeExtensions.kt
+++ b/library/src/main/kotlin/org/codice/compliance/NodeExtensions.kt
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance
+
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+import java.io.StringWriter
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
+
+/**
+ * Finds all of the first level children of a {@code Node}.
+ *
+ * @param name - Optional element name to match.
+ * @return List of child {@code Nodes}.
+ */
+fun Node.children(name: String? = null): List<Node> {
+    val predicate: (Node) -> Boolean =
+            if (name == null) {
+                { true }
+            } else {
+                { it.localName == name }
+            }
+
+    return ((this.childNodes.length - 1) downTo 0)
+            .map { this.childNodes.item(it) }
+            .filter(predicate)
+            .toList()
+}
+
+/**
+ * Finds all of the children of a {@code Node}, regardless of how deep an element is nested in its
+ * children.
+ *
+ * @param name - Optional element name to match.
+ * @return List of child {@code Nodes}.
+ */
+fun Node.recursiveChildren(name: String? = null): List<Node> {
+    val nodes = mutableListOf<Node>()
+    this.children().forEach {
+        if (name == null || name == it.localName) nodes.add(it)
+        nodes.addAll(it.recursiveChildren(name))
+    }
+    return nodes
+}
+
+/**
+ * Finds all of the siblings of a {@code Node}.
+ *
+ * @param name - Optional element name to match.
+ * @return List of sibling {code Nodes}.
+ */
+fun Node.siblings(name: String? = null): List<Node> {
+    val siblingNodes = mutableListOf<Node>()
+
+    // backwards portion
+    var tempNode = this
+    while (tempNode.previousSibling != null) {
+        tempNode = tempNode.previousSibling
+        if (name == null || tempNode.localName == name)
+            siblingNodes.add(tempNode)
+    }
+
+    // forwards portion
+    tempNode = this
+    while (tempNode.nextSibling != null) {
+        tempNode = tempNode.nextSibling
+        if (name == null || tempNode.localName == name)
+            siblingNodes.add(tempNode)
+    }
+
+    return siblingNodes
+}
+
+/**
+ * Returns all of the attributes of a {@code Node} as a {@code List} of {@code Nodes}.
+ */
+fun Node.attributeList(): List<Node> {
+    val attributesList = mutableListOf<Node>()
+    this.attributes.let {
+        for (i in it.length - 1 downTo 0) {
+            attributesList.add(it.item(i))
+        }
+    }
+    return attributesList
+}
+
+fun Node.prettyPrintXml(): String {
+    // Remove whitespaces outside tags
+    normalize()
+    val xPath = XPathFactory.newInstance().newXPath()
+    val nodeList = xPath.evaluate("//text()[normalize-space()='']",
+            this,
+            XPathConstants.NODESET) as NodeList
+    for (i in 0 until nodeList.length) {
+        val node = nodeList.item(i)
+        node.parentNode.removeChild(node)
+    }
+
+    val transformer = createTransformer()
+    val output = StringWriter()
+    transformer.transform(DOMSource(this), StreamResult(output))
+    return output.toString()
+}
+
+/**
+ * Returns the named attribute node, or null if not present.
+ */
+fun Node.attributeNode(name: String) = this.attributes?.getNamedItem(name)
+
+/**
+ * Returns the named attribute node, or null if not present.
+ */
+fun Node.attributeNodeNS(ns: String, name: String) = this.attributes?.getNamedItemNS(ns, name)
+
+/**
+ * Returns the text content of the attribute of this node, or null if not present.
+ */
+fun Node.attributeText(name: String) = attributeNode(name)?.textContent
+
+/**
+ * Returns the text content of the attribute of this node, or null if not present.
+ */
+fun Node.attributeTextNS(ns: String, name: String) = attributeNodeNS(ns, name)?.textContent


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Adds two new extension functions for getting attribute nodes (one namespace-aware and one not) and two for getting attribute textContent (with and without namespace).

*I'm not sure if there is a lot of value in the extension functions for getting the attributes themselves and am open to discussion.*

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated