### PR TITLE
MAINT - Decrypting the SAML response in the tests

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/XMLDecryptor.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/XMLDecryptor.kt
@@ -17,15 +17,14 @@ import org.apache.wss4j.common.crypto.JasyptPasswordEncryptor
 import org.apache.wss4j.common.crypto.Merlin
 import org.apache.xml.security.encryption.XMLCipher
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
+import org.codice.compliance.recursiveChildren
 import org.codice.compliance.utils.TestCommon.Companion.KEYSTORE_PASSWORD
 import org.codice.compliance.utils.TestCommon.Companion.PRIVATE_KEY_ALIAS
 import org.codice.compliance.utils.TestCommon.Companion.PRIVATE_KEY_PASSWORD
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Node
-import java.io.File
 import java.security.Key
 import java.security.Security
 import java.util.Properties
@@ -43,10 +42,12 @@ class XMLDecryptor {
 
         private val serverPrivateKey by lazy {
 
-            val encryptionFile = File(ClassLoader.getSystemResource(ENCRYPTION_FILE_NAME).toURI())
+            val encryptionFile =
+                    XMLDecryptor::class.java.classLoader.getResource(ENCRYPTION_FILE_NAME)
+
             checkNotNull(encryptionFile)
 
-            val encryptionProperties = encryptionFile.inputStream().use {
+            val encryptionProperties = encryptionFile.openStream().use {
                 Properties().apply {
                     load(it)
                 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
@@ -20,8 +20,8 @@ import org.codice.compliance.SAMLCore_2_7_3_2_a
 import org.codice.compliance.SAMLCore_6_1_a
 import org.codice.compliance.SAMLCore_6_1_b
 import org.codice.compliance.attributeText
-import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
+import org.codice.compliance.recursiveChildren
 import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.XMLDecryptor
 import org.codice.compliance.utils.XMLDecryptor.Companion.XMLDecryptorException
@@ -40,12 +40,19 @@ class EncryptionVerifier {
      *
      * @param response The response node to verify and decrypt
      */
-    fun verifyAndDecryptResponse(response: Node) {
-        sequenceOf(response.recursiveChildren("EncryptedAssertion"),
-                response.recursiveChildren("EncryptedAttribute"),
-                response.recursiveChildren("EncryptedID")).forEach {
-            it.forEach {
-                verifyAndDecryptElement(it, response)
+    fun verifyAndDecryptResponse(response: Node): Boolean {
+        val encElements = response.recursiveChildren("EncryptedAssertion") +
+                response.recursiveChildren("EncryptedAttribute") +
+                response.recursiveChildren("EncryptedID")
+
+        with(encElements) {
+            if (isEmpty()) {
+                return false
+            } else {
+                forEach {
+                    verifyAndDecryptElement(it, response)
+                }
+                return true
             }
         }
     }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
@@ -21,7 +21,6 @@ import org.codice.compliance.SAMLCore_6_1_a
 import org.codice.compliance.SAMLCore_6_1_b
 import org.codice.compliance.attributeText
 import org.codice.compliance.children
-import org.codice.compliance.recursiveChildren
 import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.XMLDecryptor
 import org.codice.compliance.utils.XMLDecryptor.Companion.XMLDecryptorException
@@ -40,24 +39,13 @@ class EncryptionVerifier {
      *
      * @param response The response node to verify and decrypt
      */
-    fun verifyAndDecryptResponse(response: Node): Boolean {
-        val encElements = response.recursiveChildren("EncryptedAssertion") +
-                response.recursiveChildren("EncryptedAttribute") +
-                response.recursiveChildren("EncryptedID")
-
-        with(encElements) {
-            if (isEmpty()) {
-                return false
-            } else {
-                forEach {
-                    verifyAndDecryptElement(it, response)
-                }
-                return true
-            }
+    fun verifyAndDecryptResponse(encElements: List<Node>) {
+        encElements.forEach {
+            verifyAndDecryptElement(it)
         }
     }
 
-    fun verifyAndDecryptElement(element: Node, response: Node) {
+    fun verifyAndDecryptElement(element: Node) {
         verifyEncryptedElement(element)
 
         try {
@@ -67,7 +55,7 @@ class EncryptionVerifier {
                     SAMLCore_6_1_a,
                     message = e.message,
                     cause = e.cause,
-                    node = response)
+                    node = element)
         }
     }
 

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -32,6 +32,7 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorate
 import org.codice.compliance.verification.binding.BindingVerifier
+import org.codice.compliance.verification.core.CoreVerifier.Companion.decryptAndValidateSchema
 import org.codice.compliance.verification.core.responses.AuthnRequestProtocolResponseVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
@@ -102,6 +103,9 @@ class PostSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
+
+            decryptAndValidateSchema(responseDom)
+
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
@@ -123,6 +127,9 @@ class PostSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
+
+            decryptAndValidateSchema(responseDom)
+
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
@@ -164,6 +171,9 @@ class PostSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
+
+            decryptAndValidateSchema(responseDom)
+
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -32,7 +32,6 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorate
 import org.codice.compliance.verification.binding.BindingVerifier
-import org.codice.compliance.verification.core.CoreVerifier.Companion.decryptAndValidateSchema
 import org.codice.compliance.verification.core.responses.AuthnRequestProtocolResponseVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
@@ -104,8 +103,6 @@ class PostSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            decryptAndValidateSchema(responseDom)
-
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
@@ -127,8 +124,6 @@ class PostSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
-
-            decryptAndValidateSchema(responseDom)
 
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
@@ -171,8 +166,6 @@ class PostSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
-
-            decryptAndValidateSchema(responseDom)
 
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -32,7 +32,6 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorate
 import org.codice.compliance.verification.binding.BindingVerifier
-import org.codice.compliance.verification.core.CoreVerifier.Companion.decryptAndValidateSchema
 import org.codice.compliance.verification.core.responses.AuthnRequestProtocolResponseVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
@@ -116,8 +115,6 @@ class RedirectSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            decryptAndValidateSchema(responseDom)
-
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST]).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -143,8 +140,6 @@ class RedirectSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
-
-            decryptAndValidateSchema(responseDom)
 
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
@@ -175,8 +170,6 @@ class RedirectSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
-
-            decryptAndValidateSchema(responseDom)
 
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -32,6 +32,7 @@ import org.codice.compliance.utils.TestCommon.Companion.authnRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.getServiceProvider
 import org.codice.compliance.utils.decorate
 import org.codice.compliance.verification.binding.BindingVerifier
+import org.codice.compliance.verification.core.CoreVerifier.Companion.decryptAndValidateSchema
 import org.codice.compliance.verification.core.responses.AuthnRequestProtocolResponseVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
@@ -114,6 +115,9 @@ class RedirectSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
+
+            decryptAndValidateSchema(responseDom)
+
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST]).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -139,6 +143,9 @@ class RedirectSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
+
+            decryptAndValidateSchema(responseDom)
+
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
@@ -168,6 +175,9 @@ class RedirectSSOTest : StringSpec() {
             idpResponse.bindingVerifier().verify()
 
             val responseDom = idpResponse.responseDom
+
+            decryptAndValidateSchema(responseDom)
+
             AuthnRequestProtocolResponseVerifier(responseDom, ID, acsUrl[HTTP_POST])
                     .verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
- Modified `verifyAndDecryptResponse` method to return Boolean
- Loop over the SAML message and run schema validation then decrypt
- Keycloak tests now pass! 🎉 
#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated