### PR TITLE
CORE - Adds JTidy to clean up HTML responses and make them valid.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     compile 'com.google.http-client:google-http-client:1.22.0'
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'org.keyczar:keyczar:0.66'
+    compile 'net.sf.jtidy:jtidy:r938'
 }

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -20,8 +20,11 @@ import org.codice.security.saml.IdpMetadata
 import org.codice.security.saml.SPMetadataParser
 import org.codice.security.saml.SamlProtocol
 import org.w3c.dom.Node
+import org.w3c.tidy.Tidy
 import java.io.File
+import java.io.StringWriter
 import java.nio.charset.StandardCharsets
+import java.util.Properties
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.transform.OutputKeys
 import javax.xml.transform.Transformer
@@ -90,8 +93,24 @@ class Common {
             return DocumentBuilderFactory.newInstance().apply {
                 isNamespaceAware = true
             }.newDocumentBuilder()
-                    .parse(inputXml.byteInputStream())
+                    .parse(tidy(inputXml).byteInputStream())
                     .documentElement
+        }
+
+        private fun tidy(input: String): String {
+            if (!"""(?i:.*<html.*)""".toRegex(RegexOption.DOT_MATCHES_ALL).matches(input)) {
+                return input
+            }
+            input.byteInputStream().use { inStr ->
+                return StringWriter().use { outStr ->
+                    Tidy().apply {
+                        setConfigurationFromProps(Properties().apply {
+                            setProperty("doctype", "omit")
+                        })
+                    }.parse(inStr, outStr)
+                    outStr.toString()
+                }
+            }
         }
     }
 }
@@ -109,7 +128,7 @@ fun String.prettyPrintXml(): String {
     return try {
         // Escape all ampersands because Keycloak does not properly escape it in POST responses
         // which causes the transform to fail.
-        val escapedString = this.replace(Regex("&([^;]+(?!(?:\\\\w|;)))"),
+        val escapedString = this.replace("""&([^;]+(?!(?:\\\\w|;)))""".toRegex(),
                 { match -> "&amp;${match.value.removePrefix("&")}" })
 
         Common.buildDom(escapedString).prettyPrintXml()


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
HTML responses should only be returned in unusual error conditions, so this change will confirm if the response is HTML and only then tidy it before parsing occurs.

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated