### PR TITLE
CORE - 3.4.1.4 Processing Rules (minus Subject comparison)

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
@@ -20,6 +20,7 @@ import org.codice.compliance.SAMLCore_3_4_1_4b
 import org.codice.compliance.SAMLCore_3_4_1_4c
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.SP_ISSUER
 import org.codice.compliance.verification.core.NameIDPolicyVerifier
 import org.codice.compliance.verification.core.ResponseVerifier
 import org.opensaml.saml.saml2.core.NameIDPolicy
@@ -56,7 +57,7 @@ class CoreAuthnRequestProtocolVerifier(override val response: Node,
 
         if (assertions.any {
                     it.recursiveChildren("AudienceRestriction").flatMap { it.children("Audience") }
-                            .none { it.textContent == "https://samlhost:8993/services/saml" }
+                            .none { it.textContent == SP_ISSUER }
                 })
             throw SAMLComplianceException.create(SAMLCore_3_4_1_4c,
                     message = "Assertion found without an AudienceRestriction referencing the " +

--- a/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
+++ b/library/src/main/kotlin/org/codice/compliance/SAMLSpecRefMessage.kt
@@ -123,6 +123,9 @@ object SAMLCore_3_4 : SAMLCoreRefMessage()
 object SAMLCore_3_4_1_1a : SAMLCoreRefMessage()
 object SAMLCore_3_4_1_1b : SAMLCoreRefMessage()
 object SAMLCore_3_4_1_1c : SAMLCoreRefMessage()
+object SAMLCore_3_4_1_4a : SAMLCoreRefMessage()
+object SAMLCore_3_4_1_4b : SAMLCoreRefMessage()
+object SAMLCore_3_4_1_4c : SAMLCoreRefMessage()
 
 object SAMLCore_3_7_1 : SAMLCoreRefMessage()
 

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -216,6 +216,14 @@ SAMLCore_3_4_1_1c=When a Format defined in Section 8.3 other than \
   value of the <NameID> within the <Subject> of any <Assertion> MUST be identical to the \
   SPNameQualifier value supplied in the <NameIDPolicy>.
 
+SAMLCore_3_4_1_4a=The responder MUST ultimately reply to an <AuthnRequest> with a <Response> \
+  message containing one or more assertions that meet the specifications defined by the request
+SAMLCore_3_4_1_4b=At least one statement in at least one assertion MUST be a <saml:AuthnStatement> \
+  that describes the authentication performed by the responder or authentication service \
+  associated with it.
+SAMLCore_3_4_1_4c=The resulting assertion(s) MUST contain a <saml:AudienceRestriction> element \
+  referencing the requester as an acceptable relying party.
+
 SAMLCore_3_7_1=This specification further restricts the schema by requiring that the Reason \
   attribute MUST be in the form of a URI reference.
 


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
- ```The responder MUST ultimately reply to an <AuthnRequest> with a <Response> message containing one or more assertions that meet the specifications defined by the request```
- ```At least one statement in at least one assertion MUST be a <saml:AuthnStatement> that describes the authentication performed by the responder or authentication service associated with it.```
- ```The resulting assertion(s) MUST contain a <saml:AudienceRestriction> element referencing the requester as an acceptable relying party. Other audiences MAY be included as deemed appropriate by the identity provider.```

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated