### PR TITLE
MAINT - Using constants defined in TestCommon

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -50,14 +50,21 @@ class TestCommon {
         const val ENTITY = "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
         const val NAMEID_ENCRYPTED = "urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted"
 
+        const val ID = "ID"
         const val ASSERTION = "Assertion"
         const val TYPE = "Type"
         const val FORMAT = "Format"
         const val SUBJECT = "Subject"
+        const val VERSION = "Version"
+        const val DESTINATION = "Destination"
+        const val STATUS_CODE = "StatusCode"
+        const val AUDIENCE = "Audience"
         const val SUBJECT_CONFIRMATION = "SubjectConfirmation"
         const val AUTHN_REQUEST = "AuthnRequest"
+        const val AUTHN_STATEMENT = "AuthnStatement"
+
         const val SAML_VERSION = "2.0"
-        const val ID = "a1chfeh0234hbifc1jjd3cb40ji0d49"
+        const val REQUEST_ID = "a1chfeh0234hbifc1jjd3cb40ji0d49"
         const val EXAMPLE_RELAY_STATE = "relay+State"
         const val RELAY_STATE_GREATER_THAN_80_BYTES = "RelayStateLongerThan80CharsIsIncorrect" +
                 "AccordingToTheSamlSpecItMustNotExceed80BytesInLength"
@@ -166,7 +173,7 @@ class TestCommon {
             return AuthnRequestBuilder().buildObject().apply {
                 issuer = IssuerBuilder().buildObject().apply { value = SP_ISSUER }
                 assertionConsumerServiceURL = acsUrl[SamlProtocol.Binding.HTTP_POST]
-                id = ID
+                id = REQUEST_ID
                 version = SAMLVersion.VERSION_20
                 issueInstant = DateTime()
                 destination = Common.getSingleSignOnLocation(binding.uri)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
@@ -30,6 +30,8 @@ import org.codice.compliance.attributeNode
 import org.codice.compliance.children
 import org.codice.compliance.debugPrettyPrintXml
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ASSERTION
+import org.codice.compliance.utils.TestCommon.Companion.DESTINATION
 import org.codice.compliance.utils.TestCommon.Companion.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.TestCommon.Companion.IDP_ERROR_RESPONSE_REMINDER_MESSAGE
 import org.codice.compliance.utils.TestCommon.Companion.MAX_RELAY_STATE_LEN
@@ -41,9 +43,7 @@ import kotlin.test.assertNotNull
 
 class PostBindingVerifier(private val response: IdpPostResponseDecorator) : BindingVerifier() {
 
-    /**
-     * Verify the response for a post binding
-     */
+    /** Verify the response for a post binding */
     override fun verify() {
         verifyHttpStatusCode(response.httpStatusCode)
         verifyNoNulls()
@@ -56,9 +56,7 @@ class PostBindingVerifier(private val response: IdpPostResponseDecorator) : Bind
         verifyPostForm()
     }
 
-    /**
-     * Verify an error response (Negative path)
-     */
+    /** Verify an error response (Negative path) */
     override fun verifyError() {
         verifyHttpStatusCodeErrorResponse(response.httpStatusCode)
         verifyNoNullsErrorResponse()
@@ -192,7 +190,7 @@ class PostBindingVerifier(private val response: IdpPostResponseDecorator) : Bind
      */
     private fun verifyPostSSO() {
         if (response.responseDom.children(SIGNATURE).isEmpty()
-                || response.responseDom.children("Assertion").any {
+                || response.responseDom.children(ASSERTION).any {
                     it.children(SIGNATURE).isEmpty()
                 })
             throw SAMLComplianceException.create(SAMLProfiles_4_1_4_5,
@@ -228,12 +226,12 @@ class PostBindingVerifier(private val response: IdpPostResponseDecorator) : Bind
      * 3.5.5.2 Security Considerations
      */
     private fun verifyPostDestination() {
-        val destination = response.responseDom.attributeNode("Destination")?.nodeValue
+        val destination = response.responseDom.attributeNode(DESTINATION)?.nodeValue
         val signatures = response.responseDom.recursiveChildren("Signature")
 
         if (signatures.isNotEmpty() && destination != acsUrl[HTTP_POST]) {
             throw SAMLComplianceException.createWithPropertyMessage(SAMLBindings_3_5_5_2_a,
-                    property = "Destination",
+                    property = DESTINATION,
                     actual = destination,
                     expected = acsUrl[HTTP_POST],
                     node = response.responseDom)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
@@ -34,9 +34,10 @@ import org.codice.compliance.SAMLBindings_3_4_6_a
 import org.codice.compliance.SAMLBindings_3_5_5_2_a
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.attributeNode
-import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
 import org.codice.compliance.debugPrettyPrintXml
+import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.DESTINATION
 import org.codice.compliance.utils.TestCommon.Companion.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.TestCommon.Companion.IDP_ERROR_RESPONSE_REMINDER_MESSAGE
 import org.codice.compliance.utils.TestCommon.Companion.MAX_RELAY_STATE_LEN
@@ -62,9 +63,7 @@ import java.nio.charset.StandardCharsets
 class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator)
     : BindingVerifier() {
 
-    /**
-     * Verify the response for a redirect binding
-     */
+    /** Verify the response for a redirect binding */
     override fun verify() {
         verifyHttpRedirectStatusCode()
         verifyNoNulls()
@@ -79,9 +78,7 @@ class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator
         }
     }
 
-    /**
-     * Verify an error response (Negative path)
-     */
+    /** Verify an error response (Negative path) */
     override fun verifyError() {
         verifyHttpRedirectStatusCodeErrorResponse()
         verifyNoNullsErrorResponse()
@@ -414,12 +411,12 @@ class RedirectBindingVerifier(private val response: IdpRedirectResponseDecorator
      * 3.4.5.2 Security Considerations
      */
     private fun verifyRedirectDestination() {
-        val destination = response.responseDom.attributeNode("Destination")?.nodeValue
+        val destination = response.responseDom.attributeNode(DESTINATION)?.nodeValue
         val signatures = response.responseDom.recursiveChildren("Signature")
 
         if (signatures.isNotEmpty() && destination != acsUrl[HTTP_REDIRECT]) {
             throw SAMLComplianceException.createWithPropertyMessage(SAMLBindings_3_5_5_2_a,
-                    property = "Destination",
+                    property = DESTINATION,
                     actual = destination,
                     expected = acsUrl[HTTP_REDIRECT],
                     node = response.responseDom)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CommonDataTypeVerifier.kt
@@ -22,6 +22,7 @@ import org.codice.compliance.SAMLCore_1_3_4
 import org.codice.compliance.SAMLSpecRefMessage
 import org.codice.compliance.attributeTextNS
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ID
 import org.codice.compliance.utils.TestCommon.Companion.XSI
 import org.w3c.dom.Node
 import java.net.URI
@@ -38,7 +39,7 @@ class CommonDataTypeVerifier {
                         type.contains("string") -> verifyStringValues(it)
                         type.contains("anyURI") -> verifyUriValues(it)
                         type.contains("dateTime") -> verifyDateTimeValues(it)
-                        type.contains("ID") -> verifyIdValues(it)
+                        type.contains(ID) -> verifyIdValues(it)
                     }
                 }
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -26,8 +26,10 @@ import org.codice.compliance.children
 import org.codice.compliance.debugWithSupplier
 import org.codice.compliance.prettyPrintXml
 import org.codice.compliance.recursiveChildren
-import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.TestCommon.Companion.ENTITY
+import org.codice.compliance.utils.TestCommon.Companion.FORMAT
+import org.codice.compliance.utils.TestCommon.Companion.REQUESTER
+import org.codice.compliance.utils.TestCommon.Companion.STATUS_CODE
 import org.codice.compliance.utils.schema.SchemaValidator
 import org.codice.compliance.verification.core.CommonDataTypeVerifier.Companion.verifyCommonDataType
 import org.w3c.dom.Node
@@ -55,12 +57,12 @@ abstract class CoreVerifier(val node: Node) {
                         actual = "[]",
                         expected = "<Status>",
                         node = node)
-            status[0].children("StatusCode").forEach {
+            status[0].children(STATUS_CODE).forEach {
                 val code = it.attributeText("Value")
 
                 if (code != expectedStatusCode) {
                     val exceptions =
-                            if (expectedStatusCode == TestCommon.REQUESTER)
+                            if (expectedStatusCode == REQUESTER)
                                 arrayOf(samlErrorCode, SAMLCore_3_2_1_d)
                             else
                                 arrayOf(samlErrorCode)
@@ -81,7 +83,7 @@ abstract class CoreVerifier(val node: Node) {
          * 8.3.6 Entity Identifier
          */
         private fun verifyEntityIdentifiers(responseDom: Node) {
-            responseDom.recursiveChildren().filter { it.attributeText("Format") == ENTITY }
+            responseDom.recursiveChildren().filter { it.attributeText(FORMAT) == ENTITY }
                     .forEach { checkEntityIdentifier(it) }
         }
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/EncryptionVerifier.kt
@@ -21,7 +21,8 @@ import org.codice.compliance.SAMLCore_6_1_a
 import org.codice.compliance.SAMLCore_6_1_b
 import org.codice.compliance.attributeText
 import org.codice.compliance.children
-import org.codice.compliance.utils.TestCommon
+import org.codice.compliance.utils.TestCommon.Companion.ELEMENT
+import org.codice.compliance.utils.TestCommon.Companion.TYPE
 import org.codice.compliance.utils.XMLDecryptor
 import org.codice.compliance.utils.XMLDecryptor.Companion.XMLDecryptorException
 import org.w3c.dom.Node
@@ -37,7 +38,7 @@ class EncryptionVerifier {
      * <li>Replacing the encrypted elements with their unencrypted values</li>
      * </ol>
      *
-     * @param response The response node to verify and decrypt
+     * @param encElements A list of encrypted nodes to verify and decrypt
      */
     fun verifyAndDecryptElements(encElements: List<Node>) {
         encElements.forEach {
@@ -45,7 +46,7 @@ class EncryptionVerifier {
         }
     }
 
-    fun verifyAndDecryptElement(element: Node) {
+    private fun verifyAndDecryptElement(element: Node) {
         verifyEncryptedElement(element)
 
         try {
@@ -62,7 +63,7 @@ class EncryptionVerifier {
     private fun verifyEncryptedElement(encryptedElement: Node) {
         if (encryptedElement.children("EncryptedData")
                         .first() // guaranteed to have an EncryptedData child by schema validation
-                        .attributeText("Type") != TestCommon.ELEMENT)
+                        .attributeText(TYPE) != ELEMENT)
             throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_6_1_b,
                     when (encryptedElement.localName) {
                         "EncryptedID" -> SAMLCore_2_2_4_a
@@ -70,9 +71,9 @@ class EncryptionVerifier {
                         "EncryptedAttribute" -> SAMLCore_2_7_3_2_a
                         else -> throw UnknownError("Unknown ${encryptedElement.localName} type.")
                     },
-                    property = TestCommon.TYPE,
-                    actual = encryptedElement.attributeText(TestCommon.TYPE),
-                    expected = TestCommon.ELEMENT,
+                    property = TYPE,
+                    actual = encryptedElement.attributeText(TYPE),
+                    expected = ELEMENT,
                     node = encryptedElement)
     }
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/NameIDPolicyVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/NameIDPolicyVerifier.kt
@@ -21,9 +21,10 @@ import org.codice.compliance.SAMLCore_3_4_1_1c
 import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
-import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.TestCommon.Companion.ASSERTION
+import org.codice.compliance.utils.TestCommon.Companion.FORMAT
 import org.codice.compliance.utils.TestCommon.Companion.NAMEID_ENCRYPTED
+import org.codice.compliance.utils.TestCommon.Companion.SUBJECT
 import org.opensaml.saml.saml2.core.NameIDPolicy
 import org.w3c.dom.Node
 
@@ -33,7 +34,7 @@ class NameIDPolicyVerifier(private val response: Node, private val policy: NameI
     internal fun verify() {
         response
                 .recursiveChildren(ASSERTION)
-                .flatMap { it.children("Subject") }
+                .flatMap { it.children(SUBJECT) }
                 .flatMap { it.children("NameID") }
                 .forEach {
                     when (policy.format) {
@@ -61,7 +62,7 @@ class NameIDPolicyVerifier(private val response: Node, private val policy: NameI
     }
 
     private fun verifyFormatsMatch(nameId: Node) {
-        nameId.attributeText("Format").let { idFormat ->
+        nameId.attributeText(FORMAT).let { idFormat ->
             if (!idFormat.equals(policy.format)) {
                 throw SAMLComplianceException.create(SAMLCore_3_4_1_1b,
                         message = "A NameID element was found with a Format attribute " +
@@ -72,9 +73,9 @@ class NameIDPolicyVerifier(private val response: Node, private val policy: NameI
     }
 
     internal fun verifyEncryptedIds() {
-        if (policy.format == TestCommon.NAMEID_ENCRYPTED) {
+        if (policy.format == NAMEID_ENCRYPTED) {
             val subjects = response.recursiveChildren(ASSERTION)
-                    .flatMap { it.children("Subject") }
+                    .flatMap { it.children(SUBJECT) }
 
             if (subjects.any { it.children("EncryptedID").isEmpty() }) {
                 throw SAMLComplianceException.create(SAMLCore_3_4_1_1a,

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/ResponseVerifier.kt
@@ -25,18 +25,17 @@ import org.codice.compliance.attributeNode
 import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.DESTINATION
+import org.codice.compliance.utils.TestCommon.Companion.ID
 import org.codice.compliance.utils.TestCommon.Companion.SAML_VERSION
+import org.codice.compliance.utils.TestCommon.Companion.STATUS_CODE
 import org.codice.compliance.utils.TestCommon.Companion.TOP_LEVEL_STATUS_CODES
+import org.codice.compliance.utils.TestCommon.Companion.VERSION
 import org.w3c.dom.Node
 
 abstract class ResponseVerifier(open val response: Node,
                                 open val id: String,
                                 open val acsUrl: String?) : CoreVerifier(response) {
-    companion object {
-        private const val VERSION = "Version"
-        private const val DESTINATION = "Destination"
-        private const val STATUS_CODE = "StatusCode"
-    }
 
     /** 3.2.2 Complex Type StatusResponseType */
     override fun verify() {
@@ -48,7 +47,7 @@ abstract class ResponseVerifier(open val response: Node,
 
     /** All SAML responses are of types that are derived from the StatusResponseType complex type.*/
     private fun verifyStatusResponseType() {
-        CommonDataTypeVerifier.verifyIdValues(response.attributeNode("ID"),
+        CommonDataTypeVerifier.verifyIdValues(response.attributeNode(ID),
                 SAMLCore_3_2_2_a)
 
         // Assuming response is generated in response to a request

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
@@ -28,6 +28,7 @@ import java.net.URISyntaxException
 import javax.xml.parsers.DocumentBuilderFactory
 
 internal class SamlDefinedIdentifiersVerifier(val node: Node) {
+
     companion object {
         private const val ATTRIBUTE_NAME_FORMAT_URI =
                 "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SignatureSyntaxAndProcessingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SignatureSyntaxAndProcessingVerifier.kt
@@ -20,6 +20,7 @@ import org.codice.compliance.SAMLCore_5_4_2_b1
 import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ID
 import org.w3c.dom.Node
 
 class SignatureSyntaxAndProcessingVerifier(private val node: Node) {
@@ -44,7 +45,7 @@ class SignatureSyntaxAndProcessingVerifier(private val node: Node) {
                             message = "URI attribute not found.",
                             node = node)
 
-            val formattedId = "#${it.parentNode.attributeText("ID")}"
+            val formattedId = "#${it.parentNode.attributeText(ID)}"
             if (uriValue != formattedId)
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_5_4_2_b,
                         property = "URI",

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SubjectComparisonVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SubjectComparisonVerifier.kt
@@ -23,6 +23,7 @@ import org.codice.compliance.attributeList
 import org.codice.compliance.attributeText
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ASSERTION
 import org.codice.compliance.utils.TestCommon.Companion.FORMAT
 import org.codice.compliance.utils.TestCommon.Companion.SUBJECT
 import org.codice.compliance.utils.TestCommon.Companion.SUBJECT_CONFIRMATION
@@ -55,7 +56,7 @@ class SubjectComparisonVerifier(private val request: Node? = null, private val r
      * order to fully test this function we need to resolve the Subjects to a principal.
      */
     fun verifySubjectsMatchSSO() {
-        val subjectSet = response.children("Assertion")
+        val subjectSet = response.children(ASSERTION)
                 .flatMap { it.children(SUBJECT) }
                 .toSet()
         Sets.combinations(subjectSet, 2).forEach {
@@ -98,7 +99,7 @@ class SubjectComparisonVerifier(private val request: Node? = null, private val r
     @Suppress("NestedBlockDepth" /* Simple `let` nesting */)
     fun verifySubjectsMatchAuthnRequest() {
 
-        val requestSubject = request?.children("Subject")?.firstOrNull() ?: return
+        val requestSubject = request?.children(SUBJECT)?.firstOrNull() ?: return
         val requestId = requestSubject.id
         val requestConfirmations = requestSubject.children(SUBJECT_CONFIRMATION)
 
@@ -107,7 +108,7 @@ class SubjectComparisonVerifier(private val request: Node? = null, private val r
         val nameIdPolicyFormat =
                 request.children("NameIDPolicy").firstOrNull()?.filteredFormatValue
 
-        response.recursiveChildren("Assertion")
+        response.recursiveChildren(ASSERTION)
                 .flatMap { it.children(SUBJECT) }
                 .forEach { resSubject ->
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/AssertionsVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/AssertionsVerifier.kt
@@ -21,18 +21,19 @@ import org.codice.compliance.SAMLCore_2_3_3_b
 import org.codice.compliance.SAMLCore_2_3_3_c
 import org.codice.compliance.attributeNode
 import org.codice.compliance.attributeNodeNS
-import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
-import org.codice.compliance.utils.TestCommon
+import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ASSERTION
+import org.codice.compliance.utils.TestCommon.Companion.AUTHN_STATEMENT
+import org.codice.compliance.utils.TestCommon.Companion.ID
 import org.codice.compliance.utils.TestCommon.Companion.SAML_VERSION
+import org.codice.compliance.utils.TestCommon.Companion.SUBJECT
+import org.codice.compliance.utils.TestCommon.Companion.VERSION
+import org.codice.compliance.utils.TestCommon.Companion.XSI
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.w3c.dom.Node
 
 internal class AssertionsVerifier(val node: Node) {
-    companion object {
-        private const val VERSION = "Version"
-    }
-
     /** 2.3 Assertions */
     fun verify() {
         verifyAssertionURIRef()
@@ -49,7 +50,7 @@ internal class AssertionsVerifier(val node: Node) {
     /** 2.3.3 Element <Assertion> */
     @Suppress("ComplexCondition")
     private fun verifyAssertion() {
-        node.recursiveChildren("Assertion").forEach {
+        node.recursiveChildren(ASSERTION).forEach {
             val version = it.attributeNode(VERSION)
             if (version?.textContent != SAML_VERSION)
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_2_3_3_a,
@@ -59,22 +60,22 @@ internal class AssertionsVerifier(val node: Node) {
                         node = node)
 
             CommonDataTypeVerifier.verifyStringValues(version)
-            CommonDataTypeVerifier.verifyIdValues(it.attributeNode("ID"),
+            CommonDataTypeVerifier.verifyIdValues(it.attributeNode(ID),
                     SAMLCore_2_3_3_b)
             CommonDataTypeVerifier.verifyDateTimeValues(it.attributeNode("IssueInstant"),
                     SAMLCore_2_3_3_c)
 
             val statements = it.children("Statement")
-            if (statements.any { it.attributeNodeNS(TestCommon.XSI, "type") == null })
+            if (statements.any { it.attributeNodeNS(XSI, "type") == null })
                 throw SAMLComplianceException.create(SAMLCore_2_2_3_a,
                         message = "Statement element found without a type.",
                         node = node)
 
             if (statements.isEmpty()
-                    && it.children("AuthnStatement").isEmpty()
+                    && it.children(AUTHN_STATEMENT).isEmpty()
                     && it.children("AuthzDecisionStatement").isEmpty()
                     && it.children("AttributeStatement").isEmpty()
-                    && it.children("Subject").isEmpty())
+                    && it.children(SUBJECT).isEmpty())
                 throw SAMLComplianceException.create(SAMLCore_2_2_3_b,
                         message = "No Subject or Statement elements found.",
                         node = node)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/ConditionsVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/ConditionsVerifier.kt
@@ -22,17 +22,15 @@ import org.codice.compliance.SAMLCore_2_5_1_a
 import org.codice.compliance.SAMLCore_2_5_1_b
 import org.codice.compliance.SAMLCore_2_5_1_c
 import org.codice.compliance.attributeNodeNS
-import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
-import org.codice.compliance.utils.TestCommon
+import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.AUDIENCE
+import org.codice.compliance.utils.TestCommon.Companion.XSI
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.codice.compliance.verification.core.CoreVerifier.Companion.validateTimeWindow
 import org.w3c.dom.Node
 
 internal class ConditionsVerifier(val node: Node) {
-    companion object {
-        private const val AUDIENCE = "Audience"
-    }
 
     /** 2.5 Conditions */
     fun verify() {
@@ -53,7 +51,7 @@ internal class ConditionsVerifier(val node: Node) {
         validateTimeWindow(conditionsElement, SAMLCore_2_5_1_2)
 
         if (conditionsElement.children("Condition")
-                        .any { it.attributeNodeNS(TestCommon.XSI, "type") == null })
+                        .any { it.attributeNodeNS(XSI, "type") == null })
             throw SAMLComplianceException.create(SAMLCore_2_5_1_a,
                     message = "Condition found without a type.",
                     node = node)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/NameIdentifierVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/NameIdentifierVerifier.kt
@@ -15,6 +15,7 @@ package org.codice.compliance.verification.core.assertions
 
 import org.codice.compliance.attributeNode
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.FORMAT
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.w3c.dom.Node
 
@@ -37,7 +38,7 @@ internal class NameIdentifierVerifier(val node: Node) {
         /** 2.2.2 Complex Type NameIDType */
         fun verifyNameIDType(node: Node) {
             verifyIdNameQualifiers(node)
-            node.attributeNode("Format")?.let {
+            node.attributeNode(FORMAT)?.let {
                 CommonDataTypeVerifier.verifyUriValues(it)
             }
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/StatementVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/StatementVerifier.kt
@@ -20,14 +20,13 @@ import org.codice.compliance.SAMLCore_2_7_4_a
 import org.codice.compliance.attributeNode
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ASSERTION
+import org.codice.compliance.utils.TestCommon.Companion.AUTHN_STATEMENT
+import org.codice.compliance.utils.TestCommon.Companion.SUBJECT
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.w3c.dom.Node
 
 internal class StatementVerifier(val node: Node) {
-    companion object {
-        private const val SUBJECT = "Subject"
-        private const val ASSERTION = "Assertion"
-    }
 
     /** 2.7 Statements */
     fun verify() {
@@ -42,7 +41,7 @@ internal class StatementVerifier(val node: Node) {
 
     /** 2.7.2 Element <AuthnStatement> **/
     private fun verifyAuthnStatement() {
-        node.recursiveChildren("AuthnStatement").forEach {
+        node.recursiveChildren(AUTHN_STATEMENT).forEach {
             CommonDataTypeVerifier.verifyDateTimeValues(it.attributeNode("AuthnInstant"))
 
             it.attributeNode("SessionIndex")?.let {
@@ -55,7 +54,7 @@ internal class StatementVerifier(val node: Node) {
         }
 
         if (node.recursiveChildren(ASSERTION)
-                        .filter { it.children("AuthnStatement").isNotEmpty() }
+                        .filter { it.children(AUTHN_STATEMENT).isNotEmpty() }
                         .any { it.children(SUBJECT).isEmpty() })
             throw SAMLComplianceException.create(SAMLCore_2_7_2,
                     message = "An AuthnStatement was found without a Subject element.",

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/SubjectVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/assertions/SubjectVerifier.kt
@@ -16,6 +16,7 @@ package org.codice.compliance.verification.core.assertions
 import org.codice.compliance.SAMLCore_2_4_1_2_a
 import org.codice.compliance.attributeNode
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.SUBJECT_CONFIRMATION
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.codice.compliance.verification.core.CoreVerifier.Companion.validateTimeWindow
 import org.w3c.dom.Node
@@ -30,7 +31,7 @@ internal class SubjectVerifier(val node: Node) {
 
     /** 2.4.1.1 Element <SubjectConfirmation> */
     private fun verifySubjectConfirmation() {
-        node.recursiveChildren("SubjectConfirmation")
+        node.recursiveChildren(SUBJECT_CONFIRMATION)
                 .forEach {
                     CommonDataTypeVerifier
                             .verifyUriValues(it.attributeNode("Method"))

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
@@ -15,11 +15,14 @@ package org.codice.compliance.verification.core.responses
 
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_4
-import org.codice.compliance.SAMLCore_3_4_1_4a
 import org.codice.compliance.SAMLCore_3_4_1_4_c
 import org.codice.compliance.SAMLCore_3_4_1_4_d
+import org.codice.compliance.SAMLCore_3_4_1_4a
 import org.codice.compliance.children
 import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ASSERTION
+import org.codice.compliance.utils.TestCommon.Companion.AUDIENCE
+import org.codice.compliance.utils.TestCommon.Companion.AUTHN_STATEMENT
 import org.codice.compliance.utils.TestCommon.Companion.SP_ISSUER
 import org.codice.compliance.verification.core.NameIDPolicyVerifier
 import org.codice.compliance.verification.core.ResponseVerifier
@@ -32,7 +35,7 @@ class CoreAuthnRequestProtocolVerifier(override val response: Node,
                                        private val nameIdPolicy: NameIDPolicy? = null) :
         ResponseVerifier(response, id, acsUrl) {
 
-    val nameIdPolicyVerifier = nameIdPolicy?.let { NameIDPolicyVerifier(response, it) }
+    private val nameIdPolicyVerifier = nameIdPolicy?.let { NameIDPolicyVerifier(response, it) }
 
     /** 3.4 Authentication Request Protocol **/
     override fun verify() {
@@ -43,20 +46,20 @@ class CoreAuthnRequestProtocolVerifier(override val response: Node,
     }
 
     private fun verifyAuthnRequestProtocolResponse() {
-        val assertions = response.children("Assertion")
+        val assertions = response.children(ASSERTION)
 
         if (response.localName != "Response" || assertions.isEmpty())
             throw SAMLComplianceException.create(SAMLCore_3_4_1_4a,
                     message = "Did not find Response elements with one or more Assertion elements.",
                     node = response)
 
-        if (assertions.all { it.children("AuthnStatement").isEmpty() })
+        if (assertions.all { it.children(AUTHN_STATEMENT).isEmpty() })
             throw SAMLComplianceException.create(SAMLCore_3_4, SAMLCore_3_4_1_4_c,
                     message = "AuthnStatement not found in any of the Assertions.",
                     node = response)
 
         if (assertions.any {
-                    it.recursiveChildren("AudienceRestriction").flatMap { it.children("Audience") }
+                    it.recursiveChildren("AudienceRestriction").flatMap { it.children(AUDIENCE) }
                             .none { it.textContent == SP_ISSUER }
                 })
             throw SAMLComplianceException.create(SAMLCore_3_4_1_4_d,

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/ProfilesVerifier.kt
@@ -21,10 +21,12 @@ import org.codice.compliance.SAMLProfiles_4_1_4_2_l
 import org.codice.compliance.SAMLSpecRefMessage
 import org.codice.compliance.attributeNodeNS
 import org.codice.compliance.attributeText
-import org.codice.compliance.recursiveChildren
 import org.codice.compliance.children
+import org.codice.compliance.recursiveChildren
+import org.codice.compliance.utils.TestCommon.Companion.ASSERTION
 import org.codice.compliance.utils.TestCommon.Companion.HOLDER_OF_KEY_URI
 import org.codice.compliance.utils.TestCommon.Companion.SAML_NAMESPACE
+import org.codice.compliance.utils.TestCommon.Companion.SUBJECT_CONFIRMATION
 import org.codice.compliance.utils.TestCommon.Companion.XSI
 import org.w3c.dom.Node
 
@@ -35,7 +37,7 @@ class ProfilesVerifier(private val node: Node) {
      * This should be called explicitly if an error is expected.
      */
     fun verifyErrorResponseAssertion(samlErrorCode: SAMLSpecRefMessage? = null) {
-        if (node.recursiveChildren("Assertion").isNotEmpty()) {
+        if (node.recursiveChildren(ASSERTION).isNotEmpty()) {
             val exceptions: Array<SAMLSpecRefMessage> =
                     if (samlErrorCode != null)
                         arrayOf(samlErrorCode, SAMLProfiles_4_1_4_2_l)
@@ -60,7 +62,7 @@ class ProfilesVerifier(private val node: Node) {
      * 3.1 Holder of Key
      */
     private fun verifyHolderOfKey() {
-        val holderOfKeyList = node.recursiveChildren("SubjectConfirmation")
+        val holderOfKeyList = node.recursiveChildren(SUBJECT_CONFIRMATION)
                 .filter { it.attributeText("Method") == HOLDER_OF_KEY_URI }
 
         if (holderOfKeyList.isEmpty()) return

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -20,7 +20,7 @@ import org.apache.wss4j.common.saml.builder.SAML2Constants
 import org.codice.compliance.debugWithSupplier
 import org.codice.compliance.saml.plugin.IdpSSOResponder
 import org.codice.compliance.utils.TestCommon.Companion.EXAMPLE_RELAY_STATE
-import org.codice.compliance.utils.TestCommon.Companion.ID
+import org.codice.compliance.utils.TestCommon.Companion.REQUEST_ID
 import org.codice.compliance.utils.TestCommon.Companion.NAMEID_ENCRYPTED
 import org.codice.compliance.utils.TestCommon.Companion.SP_ISSUER
 import org.codice.compliance.utils.TestCommon.Companion.acsUrl
@@ -55,7 +55,7 @@ class PostSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -77,7 +77,7 @@ class PostSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -101,7 +101,7 @@ class PostSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -129,7 +129,7 @@ class PostSSOTest : StringSpec() {
             val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameIDPolicy verification in
             // CoreAuthnRequestProtocolVerifier
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
@@ -158,7 +158,7 @@ class PostSSOTest : StringSpec() {
             val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameID verification
             // in CoreAuthnRequestProtocolVerifier#verifyEncryptedElements
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -21,7 +21,7 @@ import org.apache.wss4j.common.saml.builder.SAML2Constants
 import org.codice.compliance.debugWithSupplier
 import org.codice.compliance.saml.plugin.IdpSSOResponder
 import org.codice.compliance.utils.TestCommon.Companion.EXAMPLE_RELAY_STATE
-import org.codice.compliance.utils.TestCommon.Companion.ID
+import org.codice.compliance.utils.TestCommon.Companion.REQUEST_ID
 import org.codice.compliance.utils.TestCommon.Companion.NAMEID_ENCRYPTED
 import org.codice.compliance.utils.TestCommon.Companion.SP_ISSUER
 import org.codice.compliance.utils.TestCommon.Companion.acsUrl
@@ -63,7 +63,7 @@ class RedirectSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -90,7 +90,7 @@ class RedirectSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -120,7 +120,7 @@ class RedirectSSOTest : StringSpec() {
 
             val responseDom = idpResponse.responseDom
 
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
         }
@@ -154,7 +154,7 @@ class RedirectSSOTest : StringSpec() {
             val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameIDPolicy verification in
             // CoreAuthnRequestProtocolVerifier
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
@@ -190,7 +190,7 @@ class RedirectSSOTest : StringSpec() {
             val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameIDPolicy verification in
             // CoreAuthnRequestProtocolVerifier#verifyEncryptedElements
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(responseDom, REQUEST_ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
             SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.

- Some constants are defined in `TestCommon` but aren't used everywhere they could be.
- Moved other general constants to `TestCommon`

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated