### PR TITLE
[WIP] CORE 3.2.2 - Added signature verification for POST response

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/decorators/IdpPostResponseDecorator.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/decorators/IdpPostResponseDecorator.kt
@@ -23,6 +23,7 @@ import org.codice.compliance.utils.TestCommon.Companion.acsUrl
 import org.codice.compliance.verification.binding.BindingVerifier
 import org.codice.compliance.verification.binding.PostBindingVerifier
 import org.codice.security.saml.SamlProtocol
+import org.opensaml.saml.saml2.core.Response
 import com.jayway.restassured.path.xml.element.Node as raNode
 import org.w3c.dom.Node as w3Node
 
@@ -51,6 +52,11 @@ internal constructor(response: IdpPostResponse) : IdpPostResponse(response), Idp
     override val responseDom: w3Node by lazy {
         checkNotNull(decodedSamlResponse)
         buildDom(decodedSamlResponse)
+    }
+
+    override val responseObject: Response by lazy {
+        checkNotNull(decodedSamlResponse)
+        buildSamlResponse(decodedSamlResponse)
     }
 
     val isResponseFormNull: Boolean by lazy {

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/decorators/IdpRedirectResponseDecorator.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/decorators/IdpRedirectResponseDecorator.kt
@@ -20,6 +20,7 @@ import org.apache.cxf.rs.security.saml.sso.SSOConstants.SIG_ALG
 import org.codice.compliance.saml.plugin.IdpRedirectResponse
 import org.codice.compliance.verification.binding.BindingVerifier
 import org.codice.compliance.verification.binding.RedirectBindingVerifier
+import org.opensaml.saml.saml2.core.Response
 import org.w3c.dom.Node
 
 /**
@@ -55,6 +56,10 @@ internal constructor(response: IdpRedirectResponse) : IdpRedirectResponse(respon
     override val responseDom: Node by lazy {
         checkNotNull(decodedSamlResponse)
         buildDom(decodedSamlResponse)
+    }
+    override val responseObject: Response by lazy {
+        checkNotNull(decodedSamlResponse)
+        buildSamlResponse(decodedSamlResponse)
     }
 
     val isUrlNull: Boolean by lazy {

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/decorators/IdpResponseDecorator.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/decorators/IdpResponseDecorator.kt
@@ -17,12 +17,14 @@ import org.codice.compliance.Common
 import org.codice.compliance.saml.plugin.IdpPostResponse
 import org.codice.compliance.saml.plugin.IdpRedirectResponse
 import org.codice.compliance.verification.binding.BindingVerifier
+import org.opensaml.saml.saml2.core.Response
 import org.w3c.dom.Node
 
 interface IdpResponseDecorator {
     var isRelayStateGiven: Boolean
     var decodedSamlResponse: String
     val responseDom: Node
+    val responseObject: Response
 
     fun bindingVerifier(): BindingVerifier
 }
@@ -37,4 +39,8 @@ fun IdpPostResponse.decorate(): IdpPostResponseDecorator {
 
 internal fun buildDom(inputXml: String): Node {
     return Common.buildDom(inputXml)
+}
+
+internal fun buildSamlResponse(inputXml: String): Response {
+    return Common.extractSamlResponse(inputXml)
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -28,12 +28,13 @@ import org.codice.compliance.prettyPrintXml
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.TestCommon.Companion.ENTITY
+import org.codice.compliance.utils.decorators.IdpResponseDecorator
 import org.codice.compliance.utils.schema.SchemaValidator
 import org.codice.compliance.verification.core.CommonDataTypeVerifier.Companion.verifyCommonDataType
 import org.w3c.dom.Node
 import java.time.Instant
 
-abstract class CoreVerifier(val node: Node) {
+abstract class CoreVerifier(private val samlResponse: IdpResponseDecorator) {
     companion object {
         private const val ENTITY_ID_MAX_LEN = 1024
 
@@ -127,16 +128,20 @@ abstract class CoreVerifier(val node: Node) {
         }
     }
 
+    private val responseDom by lazy {
+        samlResponse.responseDom
+    }
+
     /**
      * Verify response against the Core Spec document
      */
     open fun verify() {
-        preProcess(node)
-        verifyCommonDataType(node)
-        verifyEntityIdentifiers(node)
-        SamlAssertionsVerifier(node).verify()
-        SignatureSyntaxAndProcessingVerifier(node).verify()
-        SamlDefinedIdentifiersVerifier(node).verify()
+        preProcess(responseDom)
+        verifyCommonDataType(responseDom)
+        verifyEntityIdentifiers(responseDom)
+        SamlAssertionsVerifier(responseDom).verify()
+        SignatureSyntaxAndProcessingVerifier(responseDom).verify()
+        SamlDefinedIdentifiersVerifier(responseDom).verify()
     }
 
     open fun verifyEncryptedElements() {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -53,11 +53,9 @@ class PostSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
-
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
         }
 
         "POST AuthnRequest With Relay State Test" {
@@ -75,11 +73,9 @@ class PostSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
-
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
         }
 
         "POST AuthnRequest Without ACS Url Test" {
@@ -99,11 +95,9 @@ class PostSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
-
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
         }
 
         "POST AuthnRequest With Email NameIDPolicy Format Test" {
@@ -126,12 +120,11 @@ class PostSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameIDPolicy verification in
             // CoreAuthnRequestProtocolVerifier
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
             // re-enable this test
         }.config(enabled = false)
@@ -158,9 +151,9 @@ class PostSSOTest : StringSpec() {
             val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameID verification
             // in CoreAuthnRequestProtocolVerifier#verifyEncryptedElements
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
             // re-enable this test
         }.config(enabled = false)

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -61,11 +61,9 @@ class RedirectSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
-
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
         }
 
         "Redirect AuthnRequest With Relay State Test" {
@@ -88,11 +86,9 @@ class RedirectSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
-
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
         }
 
         "Redirect AuthnRequest Without ACS Url Test" {
@@ -118,11 +114,9 @@ class RedirectSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
-
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
         }
 
         "Redirect AuthnRequest With Email NameID Format Test" {
@@ -151,12 +145,11 @@ class RedirectSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameIDPolicy verification in
             // CoreAuthnRequestProtocolVerifier
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
             // re-enable this test
         }.config(enabled = false)
@@ -187,12 +180,11 @@ class RedirectSSOTest : StringSpec() {
             // SingleSignOnProfileVerifier.verifyBinding(idpResponse)
             idpResponse.bindingVerifier().verify()
 
-            val responseDom = idpResponse.responseDom
             // Main goal of this test is to do the NameIDPolicy verification in
             // CoreAuthnRequestProtocolVerifier#verifyEncryptedElements
-            CoreAuthnRequestProtocolVerifier(responseDom, ID, acsUrl[HTTP_POST],
+            CoreAuthnRequestProtocolVerifier(idpResponse, ID, acsUrl[HTTP_POST],
                     authnRequest.nameIDPolicy).verify()
-            SingleSignOnProfileVerifier(responseDom, acsUrl[HTTP_POST]).verify()
+            SingleSignOnProfileVerifier(idpResponse.responseDom, acsUrl[HTTP_POST]).verify()
             // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
             // re-enable this test
         }.config(enabled = false)

--- a/library/src/main/java/org/codice/security/sign/SimpleSign.java
+++ b/library/src/main/java/org/codice/security/sign/SimpleSign.java
@@ -34,15 +34,26 @@ import org.apache.cxf.rs.security.saml.sso.SSOConstants;
 import org.apache.wss4j.common.crypto.CryptoType;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.apache.wss4j.common.saml.SAMLKeyInfo;
+import org.apache.wss4j.common.saml.SAMLUtil;
+import org.apache.wss4j.dom.engine.WSSConfig;
+import org.apache.wss4j.dom.handler.RequestData;
+import org.apache.wss4j.dom.saml.WSSSAMLKeyInfoProcessor;
+import org.apache.wss4j.dom.validate.Credential;
+import org.apache.wss4j.dom.validate.SignatureTrustValidator;
+import org.apache.wss4j.dom.validate.Validator;
 import org.opensaml.saml.common.SAMLObjectContentReference;
 import org.opensaml.saml.common.SignableSAMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.xmlsec.keyinfo.impl.X509KeyInfoGeneratorFactory;
 import org.opensaml.xmlsec.signature.KeyInfo;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import org.opensaml.xmlsec.signature.support.SignatureValidator;
+import org.opensaml.xmlsec.signature.support.provider.ApacheSantuarioSignatureValidationProviderImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -238,6 +249,76 @@ public class SimpleSign {
         | java.security.SignatureException
         | IllegalArgumentException e) {
       throw new SignatureException(e);
+    }
+  }
+
+  public void validateSignature(Signature signature) throws SignatureException {
+    RequestData requestData = new RequestData();
+    requestData.setSigVerCrypto(crypto.getSignatureCrypto());
+    WSSConfig wssConfig = WSSConfig.getNewInstance();
+    requestData.setWssConfig(wssConfig);
+
+    SAMLKeyInfo samlKeyInfo = null;
+
+    KeyInfo keyInfo = signature.getKeyInfo();
+    if (keyInfo != null) {
+      try {
+        samlKeyInfo =
+            SAMLUtil.getCredentialFromKeyInfo(
+                keyInfo.getDOM(),
+                new WSSSAMLKeyInfoProcessor(requestData),
+                crypto.getSignatureCrypto());
+      } catch (WSSecurityException e) {
+        throw new SignatureException("Unable to get KeyInfo.", e);
+      }
+    }
+    if (samlKeyInfo == null) {
+      throw new SignatureException("No KeyInfo supplied in the signature");
+    }
+
+    validateSignatureAndSamlKey(signature, samlKeyInfo);
+
+    Credential trustCredential = new Credential();
+    trustCredential.setPublicKey(samlKeyInfo.getPublicKey());
+    trustCredential.setCertificates(samlKeyInfo.getCerts());
+    Validator signatureValidator = new SignatureTrustValidator();
+
+    try {
+      signatureValidator.validate(trustCredential, requestData);
+    } catch (WSSecurityException e) {
+      throw new SignatureException("Error validating signature", e);
+    }
+  }
+
+  private void validateSignatureAndSamlKey(Signature signature, SAMLKeyInfo samlKeyInfo)
+      throws SignatureException {
+    SAMLSignatureProfileValidator validator = new SAMLSignatureProfileValidator();
+    try {
+      validator.validate(signature);
+    } catch (org.opensaml.xmlsec.signature.support.SignatureException e) {
+      throw new SignatureException("Error validating the SAMLKey signature", e);
+    }
+
+    BasicX509Credential credential = null;
+    if (samlKeyInfo.getCerts() != null) {
+      credential = new BasicX509Credential(samlKeyInfo.getCerts()[0]);
+    } else {
+      throw new SignatureException("Can't get X509Certificate or PublicKey to verify signature.");
+    }
+
+    ClassLoader threadLoader = null;
+    try {
+      threadLoader = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread()
+          .setContextClassLoader(
+              ApacheSantuarioSignatureValidationProviderImpl.class.getClassLoader());
+      SignatureValidator.validate(signature, credential);
+    } catch (org.opensaml.xmlsec.signature.support.SignatureException e) {
+      throw new SignatureException("Error validating the XML signature", e);
+    } finally {
+      if (threadLoader != null) {
+        Thread.currentThread().setContextClassLoader(threadLoader);
+      }
     }
   }
 

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -15,12 +15,16 @@ package org.codice.compliance
 
 import de.jupf.staticlog.Log
 import de.jupf.staticlog.core.LogLevel
+import org.apache.cxf.staxutils.StaxUtils
+import org.apache.wss4j.common.saml.OpenSAMLUtil
 import org.codice.security.saml.EntityInformation
 import org.codice.security.saml.IdpMetadata
 import org.codice.security.saml.SPMetadataParser
 import org.codice.security.saml.SamlProtocol
+import org.opensaml.saml.saml2.core.Response
 import org.w3c.dom.Node
 import org.w3c.tidy.Tidy
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.StringWriter
 import java.nio.charset.StandardCharsets
@@ -95,6 +99,12 @@ class Common {
             }.newDocumentBuilder()
                     .parse(tidy(inputXml).byteInputStream())
                     .documentElement
+        }
+
+        fun extractSamlResponse(samlResponse: String): Response {
+            val responseDoc = StaxUtils.read(
+                    ByteArrayInputStream(samlResponse.toByteArray(StandardCharsets.UTF_8)))
+            return OpenSAMLUtil.fromDom(responseDoc.documentElement) as Response
         }
 
         private fun tidy(input: String): String {


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Validating the POST response's signature.

This is a WIP PR. I am creating it to get your opinions about using objects instead of `Node`. DDF's `SimpleSign` takes in a `Signature` object so this may be a good way of validating the signature. Moving forward we can gradually convert passing `Node`s to actual object too.

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated