### PR TITLE
MAINT - Re-enable error tests

### DIFF
--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
@@ -120,7 +120,7 @@ class PostSSOErrorTest : StringSpec() {
                 val response = sendPostAuthnRequest(encodedRequest)
                 BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
-                val samlResponseDom = response.getBindingVerifier().decodeAndVerifyError()
+            response.getBindingVerifier().decodeAndVerifyError()
 
                 // DDF returns a valid response to the incorrect url
             } catch (e: SAMLComplianceException) {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
@@ -61,7 +61,7 @@ class PostSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "Empty POST AuthnRequest Test" {
             try {
@@ -82,7 +82,7 @@ class PostSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "POST AuthnRequest With Empty Subject Test" {
             try {
@@ -106,7 +106,7 @@ class PostSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "POST AuthnRequest With Incorrect ACS URL And Index Test" {
             try {
@@ -126,7 +126,7 @@ class PostSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "POST AuthnRequest With Non-Matching Destination" {
             try {
@@ -147,6 +147,6 @@ class PostSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
     }
 }

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
@@ -165,7 +165,7 @@ class RedirectSSOErrorTest : StringSpec() {
                 val response = sendRedirectAuthnRequest(queryParams)
                 BindingVerifier.verifyHttpStatusCode(response.statusCode)
 
-                val samlResponseDom = response.getBindingVerifier().decodeAndVerifyError()
+            response.getBindingVerifier().decodeAndVerifyError()
 
                 // DDF returns a valid response to the incorrect url
             } catch (e: SAMLComplianceException) {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
@@ -68,7 +68,7 @@ class RedirectSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "Redirect Incomplete AuthnRequest In URL Query Test" {
             try {
@@ -96,7 +96,7 @@ class RedirectSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "Empty Redirect AuthnRequest Test" {
             try {
@@ -117,7 +117,7 @@ class RedirectSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "Redirect AuthnRequest With Empty Subject Test" {
             try {
@@ -146,7 +146,7 @@ class RedirectSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "Redirect AuthnRequest With Incorrect ACS URL And Index Test" {
             try {
@@ -171,7 +171,7 @@ class RedirectSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
 
         "Redirect AuthnRequest With Non-Matching Destination" {
             try {
@@ -196,6 +196,6 @@ class RedirectSSOErrorTest : StringSpec() {
             } catch (e: SAMLComplianceException) {
                 throw SAMLComplianceException.recreateExceptionWithErrorMessage(e)
             }
-        }.config(enabled = false)
+        }
     }
 }

--- a/deployment/docker/wait.sh
+++ b/deployment/docker/wait.sh
@@ -34,4 +34,4 @@ done
 curl -LsSk "https://${_sut_host}:${_sut_port}/${_sut_idp_metadata}" -o "${_sut_ddf_implementation}/ddf-idp-metadata.xml"
 
 >&2 echo "DDF is up - executing command"
-exec ./samlconf/bin/samlconf -i ${_sut_ddf_implementation} -e
+exec ./samlconf/bin/samlconf -i ${_sut_ddf_implementation}


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
I couldn't run these even with the `-e` option when heroing Blen's PR. This re-enables them (though they still won't run from the script without `-e`).
#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated