### PR TITLE
MAINT - Moves JUnit Jupiter test dependencies out of root build file 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,6 @@ subprojects {
         compile "io.kotlintest:kotlintest-runner-junit5:$kotlin_test_version"
         compile "org.junit.platform:junit-platform-suite-api:$junit_platform_version"
         compile "org.junit.platform:junit-platform-runner:$junit_platform_version"
-
-        testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
-        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
     }
 
     test {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'org.keyczar:keyczar:0.66'
     compile 'net.sf.jtidy:jtidy:r938'
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
 }


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Moves them into the `library` module as it is the only place in which JUnit tests exist.

This will reduce (not completely eliminate) the reporting of the dummy `foo` test in kotlintest output. See [this issue on the kotlintest](https://github.com/kotlintest/kotlintest/issues/317) repo for more details.


#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated