### PR TITLE
Core 5 - Enveloped Signatures

### DIFF
--- a/ctk/idp/coverage/Core.md
+++ b/ctk/idp/coverage/Core.md
@@ -120,11 +120,11 @@ Unmarked sections need attention
 -	5.1 Signing Assertions
 -	5.2 Request/Response Signing
 -	5.3 Signature Inheritance
-	5.4 XML Signature Profile
-		5.4.1 Signing Formats and Algorithms
++	5.4 XML Signature Profile
++		5.4.1 Signing Formats and Algorithms
 +		5.4.2 References
 -		5.4.3 Canonicalization Method
-		5.4.4 Transforms
+-		5.4.4 Transforms
 -		5.4.5 [E91] Object
 -		5.4.6 KeyInfo
 -		5.4.7 Example

--- a/library/src/main/resources/SAMLSpecRefMessage.properties
+++ b/library/src/main/resources/SAMLSpecRefMessage.properties
@@ -414,8 +414,13 @@ SAMLGeneral_a=An error occurred while validating the signature. See section 3.4.
   document (including the XMLSig document referenced in that section) for instructions on how the \
   signature is validated.
 
-SAMLGeneral_b=An error occurred while validating the signature. See section 5 of the Core document \
-  titled SAML and XML Signature Syntax and Processing, for more information on signatures.
+SAMLGeneral_b=An error occurred while validating the signature. Make sure that all the signatures \
+  are enveloped. \n \
+  - SAMLCore 5: Unless a profile specifies an alternative signature mechanism, any XML Digital \
+  Signatures MUST be enveloped. \n \
+  - SAMLCore 5.4.1: SAML assertions and protocols MUST use enveloped signatures when signing assertions \
+  and protocol messages. \n \
+  See section 5 of the Core document for more information on signatures.
 
 SAMLGeneral_c=This project is intended to be a set of blackbox tests that verify the conformance of \
   an IdP/SP to the SAML V2.0 Standard Specification. It only supports SAML Version 2.0 and all other \


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
- Unless a profile specifies an alternative signature mechanism, any XML Digital Signatures MUST be enveloped.
- SAML assertions and protocols MUST use enveloped signatures when signing assertions and protocol messages.

Exception looks like:
![screen shot 2018-05-09 at 1 36 06 pm](https://user-images.githubusercontent.com/29550062/39838388-20c95a0e-538e-11e8-950b-79b9eb20aae1.png)

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated