### PR TITLE
MAINT: removes deprecated method invocations and bumps guava to latest version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ project.ext {
     kotlin_test_version = '3.1.4'
     rest_assured_version = '2.9.0'
     org_slf4j_version = '1.7.1'
-    guava_version = '24.0-jre'
+    guava_version = '25.1-jre'
     detekt_version = '1.0.0.RC6-4'
     java_encoding = 'UTF-8'
     static_log_version = '2.2.0'

--- a/library/src/test/java/org/codice/security/saml/IdpMetadataTest.java
+++ b/library/src/test/java/org/codice/security/saml/IdpMetadataTest.java
@@ -31,9 +31,10 @@ public class IdpMetadataTest {
   @Test
   public void testParseIdPMetadata() throws Exception {
     String metadataString =
-        Files.toString(
-            new File(getClass().getClassLoader().getResource("ddf-idp-metadata.xml").toURI()),
-            StandardCharsets.UTF_8);
+        Files.asCharSource(
+                new File(getClass().getClassLoader().getResource("ddf-idp-metadata.xml").toURI()),
+                StandardCharsets.UTF_8)
+            .read();
 
     IdpMetadata idpMetadata = new IdpMetadata();
     idpMetadata.setMetadata(metadataString);

--- a/library/src/test/java/org/codice/security/saml/SPMetadataParserTest.java
+++ b/library/src/test/java/org/codice/security/saml/SPMetadataParserTest.java
@@ -32,9 +32,10 @@ public class SPMetadataParserTest {
   @Test
   public void testParseSPMetadata() throws Exception {
     String metadataString =
-        Files.toString(
-            new File(getClass().getClassLoader().getResource("test-sp-metadata.xml").toURI()),
-            StandardCharsets.UTF_8);
+        Files.asCharSource(
+                new File(getClass().getClassLoader().getResource("test-sp-metadata.xml").toURI()),
+                StandardCharsets.UTF_8)
+            .read();
 
     Map<String, EntityInformation> spMetadata =
         SPMetadataParser.parse(


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
I happened to be in one of those files and noticed the deprecated method being invoked. Figured I'd clean it up.

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified