### PR TITLE
Disable SSO/SLO tests if those protocols aren't supported according to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ The `samlconf` script may take the following parameters:
     
     DESCRIPTION
            Runs the SAML Conformance Tests which test the compliance of an IdP
-           with the SAML Specifications. If a compliance issue is identified, a 
-           SAMLConformanceException will be thrown with an explanation of the error and a direct
-           quote from the specification. All of the parameters are optional and if they are 
-           not provided, the default values will use DDF's parameters.
+           with the SAML Specifications. If a compliance issue is identified, a
+           SAMLComplianceException will be thrown with an explanation of the error and a direct
+           quote from the specification. Tests will not run if the corresponding
+           endpoints do not exist in the IdP's metadata. All of the parameters
+           are optional and if they are not provided, the default values will use DDF's parameters.
     
     OPTIONS
            -i path

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -22,7 +22,6 @@ import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_RESPONSE
 import org.apache.wss4j.common.saml.OpenSAMLUtil
 import org.apache.wss4j.common.util.DOM2Writer
-import org.codice.compliance.Common.Companion.parseIdpMetadata
 import org.codice.compliance.Common.Companion.parseSpMetadata
 import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.SAMLComplianceException
@@ -133,12 +132,11 @@ class TestCommon {
         }
 
         private fun parseAndVerifyVersion(): IdpMetadata {
-            val metadata = parseIdpMetadata()
-            if (metadata.descriptor.supportedProtocols.none { it.contains("2.0") })
+            if (idpMetadata.descriptor.supportedProtocols.none { it.contains("2.0") })
                 throw SAMLComplianceException.create(SAMLGeneral_c,
                     message = "The protocolSupportEnumeration's version specified in the metadata" +
                         " is not 2.0 and not supported by this conformance test kit.")
-            return metadata
+            return idpMetadata
         }
 
         /**

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -22,6 +22,7 @@ import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_RESPONSE
 import org.apache.wss4j.common.saml.OpenSAMLUtil
 import org.apache.wss4j.common.util.DOM2Writer
+import org.codice.compliance.Common.Companion.idpMetadataObject
 import org.codice.compliance.Common.Companion.parseSpMetadata
 import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.SAMLComplianceException
@@ -132,11 +133,11 @@ class TestCommon {
         }
 
         private fun parseAndVerifyVersion(): IdpMetadata {
-            if (idpMetadata.descriptor.supportedProtocols.none { it.contains("2.0") })
+            if (idpMetadataObject.descriptor.supportedProtocols.none { it.contains("2.0") })
                 throw SAMLComplianceException.create(SAMLGeneral_c,
                     message = "The protocolSupportEnumeration's version specified in the metadata" +
                         " is not 2.0 and not supported by this conformance test kit.")
-            return idpMetadata
+            return idpMetadataObject
         }
 
         /**

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
@@ -162,12 +162,12 @@ internal class SamlDefinedIdentifiersVerifier(val node: Node) {
                     // TODO - Uncomment when DDF returns correct NameQualifier and add unit tests
                     /*
                     it.attributeText("NameQualifier")?.let { nameQualifier ->
-                        if (nameQualifier != idpMetadata.entityId)
+                        if (nameQualifier != idpMetadataObject.entityId)
                             throw SAMLComplianceException.create(SAMLCore_8_3_7_b,
                                     SAMLCore_8_3_7_c,
                                     message = "The Persistent ID's NameQualifier " +
                                             "[$nameQualifier] is not equal to " +
-                                            "${idpMetadata.entityId}",
+                                            "${idpMetadataObject.entityId}",
                                     node = it)
                     }
                     */

--- a/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
+++ b/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
@@ -13,6 +13,7 @@
  */
 package io.kotlintest.provided
 
+import de.jupf.staticlog.Log
 import io.kotlintest.AbstractProjectConfig
 import io.kotlintest.Tag
 import io.kotlintest.extensions.TestListener
@@ -31,15 +32,24 @@ object ProjectConfig : AbstractProjectConfig() {
     override fun beforeAll() {
         RestAssured.config = config().redirect(redirectConfig().followRedirects(false))
 
-        val listOfExclusions = mutableListOf<Tag>()
+        val setOfExclusions = mutableSetOf<Tag>()
 
-        if (Common.idpMetadataObject.descriptor?.singleLogoutServices?.isEmpty() == true)
-            listOfExclusions.add(SLO)
+        if (Common.idpMetadataObject.descriptor?.singleSignOnServices?.isEmpty() == true) {
+            Log.warn("SSO endpoints were not found in the IdP's metadata. " +
+                "Disabling SSO and SLO tests.")
+            setOfExclusions.apply {
+                add(SSO)
+                add(SLO)
+            }
+        }
 
-        if (Common.idpMetadataObject.descriptor?.singleSignOnServices?.isEmpty() == true)
-            listOfExclusions.add(SSO)
+        if (Common.idpMetadataObject.descriptor?.singleLogoutServices?.isEmpty() == true) {
+            Log.warn("SSO endpoints were not found in the IdP's metadata. " +
+                "Disabling SLO tests.")
+            setOfExclusions.add(SLO)
+        }
 
         System.setProperty("kotlintest.tags.exclude",
-                listOfExclusions.joinToString(",", transform = { it.name }))
+            setOfExclusions.joinToString(",", transform = { it.name }))
     }
 }

--- a/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
+++ b/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
@@ -33,10 +33,10 @@ object ProjectConfig : AbstractProjectConfig() {
 
         val listOfExclusions = mutableListOf<Tag>()
 
-        if (Common.idpMetadata.descriptor?.singleLogoutServices?.isEmpty() == true)
+        if (Common.idpMetadataObject.descriptor?.singleLogoutServices?.isEmpty() == true)
             listOfExclusions.add(SLO)
 
-        if (Common.idpMetadata.descriptor?.singleSignOnServices?.isEmpty() == true)
+        if (Common.idpMetadataObject.descriptor?.singleSignOnServices?.isEmpty() == true)
             listOfExclusions.add(SSO)
 
         System.setProperty("kotlintest.tags.exclude",

--- a/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
+++ b/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
@@ -14,16 +14,32 @@
 package io.kotlintest.provided
 
 import io.kotlintest.AbstractProjectConfig
+import io.kotlintest.Tag
 import io.kotlintest.extensions.TestListener
 import io.restassured.RestAssured
 import io.restassured.RestAssured.config
 import io.restassured.config.RedirectConfig.redirectConfig
+import org.codice.compliance.Common
 import org.codice.compliance.utils.GlobalSession
+
+object SLO : Tag()
+object SSO : Tag()
 
 object ProjectConfig : AbstractProjectConfig() {
     override fun listeners(): List<TestListener> = listOf(GlobalSession)
 
     override fun beforeAll() {
         RestAssured.config = config().redirect(redirectConfig().followRedirects(false))
+
+        val listOfExclusions = mutableListOf<Tag>()
+
+        if (Common.idpMetadata.descriptor?.singleLogoutServices?.isEmpty() == true)
+            listOfExclusions.add(SLO)
+
+        if (Common.idpMetadata.descriptor?.singleSignOnServices?.isEmpty() == true)
+            listOfExclusions.add(SSO)
+
+        System.setProperty("kotlintest.tags.exclude",
+                listOfExclusions.joinToString(",", transform = { it.name }))
     }
 }

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/PostSLOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/PostSLOTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.slo
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SLO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
@@ -32,6 +34,7 @@ import org.codice.compliance.verification.core.responses.CoreLogoutResponseProto
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 
 class PostSLOTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SLO))
 
     init {
         RestAssured.useRelaxedHTTPSValidation()

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.slo
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SLO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
@@ -35,6 +37,7 @@ import org.codice.compliance.verification.core.responses.CoreLogoutResponseProto
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
 
 class RedirectSLOTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SLO))
 
     init {
         RestAssured.useRelaxedHTTPSValidation()

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/error/PostSLOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/error/PostSLOErrorTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.slo.error
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SLO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
@@ -32,6 +34,7 @@ import org.codice.compliance.verification.core.CoreVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 
 class PostSLOErrorTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SLO))
 
     init {
         RestAssured.useRelaxedHTTPSValidation()

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/error/RedirectSLOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/error/RedirectSLOErrorTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.slo.error
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SLO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
@@ -34,6 +36,7 @@ import org.codice.compliance.verification.core.CoreVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
 
 class RedirectSLOErrorTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SLO))
 
     init {
         RestAssured.useRelaxedHTTPSValidation()

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.sso
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.wss4j.common.saml.builder.SAML2Constants
@@ -32,6 +34,8 @@ import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 
 class PostSSOTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SSO))
+
     init {
         RestAssured.useRelaxedHTTPSValidation()
 

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.sso
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
@@ -35,6 +37,8 @@ import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
 import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 
 class RedirectSSOTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SSO))
+
     init {
         RestAssured.useRelaxedHTTPSValidation()
 

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.sso.error
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
@@ -38,6 +40,8 @@ import org.opensaml.saml.saml2.core.impl.NameIDBuilder
 import org.opensaml.saml.saml2.core.impl.SubjectBuilder
 
 class PostSSOErrorTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SSO))
+
     init {
         RestAssured.useRelaxedHTTPSValidation()
         val isLenient = System.getProperty(LENIENT_ERROR_VERIFICATION) == "true"

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
@@ -13,6 +13,8 @@
  */
 package org.codice.compliance.web.sso.error
 
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
@@ -39,6 +41,8 @@ import org.opensaml.saml.saml2.core.impl.NameIDBuilder
 import org.opensaml.saml.saml2.core.impl.SubjectBuilder
 
 class RedirectSSOErrorTest : StringSpec() {
+    override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SSO))
+
     init {
         RestAssured.useRelaxedHTTPSValidation()
         val isLenient = System.getProperty(LENIENT_ERROR_VERIFICATION) == "true"

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -55,7 +55,7 @@ class Common {
         /**
          * Parses and returns the idp metadata
          */
-        val idpMetadata by lazy {
+        val idpMetadataObject by lazy {
             IdpMetadata().apply {
                 setMetadata(IDP_METADATA_STRING)
             }
@@ -80,7 +80,7 @@ class Common {
          * Returns SSO url of the passed in binding from the IdP's metadata
          */
         fun getSingleSignOnLocation(binding: String): String? {
-            return idpMetadata
+            return idpMetadataObject
                     .descriptor
                     ?.singleSignOnServices
                     ?.first { it.binding == binding }
@@ -91,7 +91,7 @@ class Common {
          * Returns SLO url of the passed in binding from the IdP's metadata
          */
         fun getSingleLogoutLocation(binding: String): String? {
-            return idpMetadata
+            return idpMetadataObject
                 .descriptor
                 ?.singleLogoutServices
                 ?.first { it.binding == binding }

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -42,7 +42,7 @@ class Common {
                 SamlProtocol.Binding.HTTP_REDIRECT
         )
 
-        private val IDP_METADATA by lazy {
+        private val IDP_METADATA_STRING by lazy {
             requireNotNull(System.getProperty(IMPLEMENTATION_PATH)) {
                 "Value required for $IMPLEMENTATION_PATH System property."
             }
@@ -50,6 +50,15 @@ class Common {
             File(System.getProperty(IMPLEMENTATION_PATH)).walkTopDown().first {
                 it.name.endsWith("idp-metadata.xml")
             }.readText()
+        }
+
+        /**
+         * Parses and returns the idp metadata
+         */
+        val idpMetadata by lazy {
+            IdpMetadata().apply {
+                setMetadata(IDP_METADATA_STRING)
+            }
         }
 
         private val TEST_SP_METADATA by lazy {
@@ -68,19 +77,10 @@ class Common {
         }
 
         /**
-         * Parses and returns the idp metadata
-         */
-        fun parseIdpMetadata(): IdpMetadata {
-            return IdpMetadata().apply {
-                setMetadata(IDP_METADATA)
-            }
-        }
-
-        /**
          * Returns SSO url of the passed in binding from the IdP's metadata
          */
         fun getSingleSignOnLocation(binding: String): String? {
-            return parseIdpMetadata()
+            return idpMetadata
                     .descriptor
                     ?.singleSignOnServices
                     ?.first { it.binding == binding }
@@ -91,7 +91,7 @@ class Common {
          * Returns SLO url of the passed in binding from the IdP's metadata
          */
         fun getSingleLogoutLocation(binding: String): String? {
-            return parseIdpMetadata()
+            return idpMetadata
                 .descriptor
                 ?.singleLogoutServices
                 ?.first { it.binding == binding }


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
* Fixed so we aren't creating a new IdpMetadata object every time it's accessed
* Tagged all tests with SSO or SLO
* Added to the ProjectConfig to exclude tests that are tagged with a profile that's unsupported
#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified