### PR TITLE
MAINT - Added -u option to the run script to provide username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ The `samlconf` script may take the following parameters:
            are optional and if they are not provided, the default values will use DDF's parameters.
     
     OPTIONS
-           -i path
-                The path to the directory containing the implementation's plugin and metadata.
-                The default value is `/implementations/ddf`.
-                      
            -d
                 Boolean for whether or not to enable debug mode which enables more logging.
                 The default value is false.
+
+           -i path
+                The path to the directory containing the implementation's plugin and metadata.
+                The default value is /implementations/ddf.
 
            -l
                 When an error occurs, the SAML V2.0 Standard Specification requires an IdP to 
@@ -87,6 +87,10 @@ The `samlconf` script may take the following parameters:
                 a valid error response (i.e. 400's and 500's).
                 If it is not given, this test kit will only verify that a valid SAML error 
                 response is returned.
+
+           -u username:password
+                The username and password to use when logging in.
+                The default value is admin:admin.
 
 ## Project Structure
 This section will briefly talk about the project structure.

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/SLOCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/SLOCommon.kt
@@ -34,6 +34,7 @@ import org.codice.compliance.utils.TestCommon.Companion.idpMetadata
 import org.codice.compliance.utils.TestCommon.Companion.signAndEncodePostRequestToString
 import org.codice.compliance.utils.TestCommon.Companion.useDSAServiceProvider
 import org.codice.compliance.utils.TestCommon.Companion.useDefaultServiceProvider
+import org.codice.compliance.utils.TestCommon.Companion.username
 import org.codice.compliance.utils.sign.SimpleSign
 import org.codice.compliance.verification.binding.BindingVerifier.Companion.verifyHttpStatusCode
 import org.codice.security.saml.SamlProtocol
@@ -141,7 +142,7 @@ class SLOCommon {
                     nameQualifier = idpMetadata.entityId
                     spNameQualifier = currentSPIssuer
                     format = PERSISTENT_ID
-                    value = "admin"
+                    value = username
                 }
             }
         }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -27,6 +27,7 @@ import org.codice.compliance.Common.Companion.parseSpMetadata
 import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLGeneral_c
+import org.codice.compliance.USER_LOGIN
 import org.codice.compliance.debugPrettyPrintXml
 import org.codice.compliance.utils.sign.SimpleSign
 import org.codice.security.saml.IdpMetadata
@@ -67,6 +68,10 @@ class TestCommon {
             getDeployDirClassloader()
         }
 
+        val username by lazy {
+            System.getProperty(USER_LOGIN).split(":").first()
+        }
+
         val idpMetadata by lazy {
             parseAndVerifyVersion()
         }
@@ -89,8 +94,8 @@ class TestCommon {
 
         object UseDSASigningSP : TestCaseExtension {
             override fun intercept(context: TestCaseInterceptContext,
-                test: (TestCaseConfig, (TestResult) -> Unit) -> Unit,
-                complete: (TestResult) -> Unit) {
+                                   test: (TestCaseConfig, (TestResult) -> Unit) -> Unit,
+                                   complete: (TestResult) -> Unit) {
                 useDSAServiceProvider()
                 test(context.config, { complete(it) })
                 useDefaultServiceProvider()
@@ -135,8 +140,9 @@ class TestCommon {
         private fun parseAndVerifyVersion(): IdpMetadata {
             if (idpMetadataObject.descriptor.supportedProtocols.none { it.contains("2.0") })
                 throw SAMLComplianceException.create(SAMLGeneral_c,
-                    message = "The protocolSupportEnumeration's version specified in the metadata" +
-                        " is not 2.0 and not supported by this conformance test kit.")
+                        message = "The protocolSupportEnumeration's version specified in the " +
+                                "metadata is not 2.0 and not supported by this conformance test " +
+                                "kit.")
             return idpMetadataObject
         }
 
@@ -158,7 +164,7 @@ class TestCommon {
          * @return The signed object as a String
          */
         fun signAndEncodePostRequestToString(samlObject: SignableSAMLObject,
-            relayState: String? = null): String {
+                                             relayState: String? = null): String {
             val samlType = if (samlObject is RequestAbstractType) SAML_REQUEST else SAML_RESPONSE
 
             SimpleSign().signSamlObject(samlObject)

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/response/CoreLogoutResponseProtocolVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/response/CoreLogoutResponseProtocolVerifierSpec.kt
@@ -66,7 +66,7 @@ class CoreLogoutResponseProtocolVerifierSpec : StringSpec() {
             Common.buildDom(createLogoutResponse(RESPONDER)).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreLogoutResponseProtocolVerifier(logoutRequest, it, HTTP_POST, SUCCESS)
-                        .verify()
+                            .verify()
                 }.apply {
                     this.message?.shouldContain(SAMLCore_3_7_3_2_b.message)
                     this.message?.shouldContain(SAMLCore_3_7_3_2_d.message)
@@ -78,7 +78,7 @@ class CoreLogoutResponseProtocolVerifierSpec : StringSpec() {
             Common.buildDom(createLogoutResponse(null)).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreLogoutResponseProtocolVerifier(logoutRequest, it, HTTP_POST, SUCCESS)
-                        .verify()
+                            .verify()
                 }.apply {
                     this.message?.shouldContain(SAMLCore_3_7_3_2_b.message)
                     this.message?.shouldContain(SAMLCore_3_7_3_2_d.message)

--- a/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
+++ b/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
@@ -18,6 +18,7 @@ import de.jupf.staticlog.core.LogLevel
 import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
 import org.codice.compliance.TEST_SP_METADATA_PROPERTY
+import org.codice.compliance.USER_LOGIN
 import org.codice.compliance.web.slo.PostSLOTest
 import org.codice.compliance.web.slo.RedirectSLOTest
 import org.codice.compliance.web.slo.error.PostSLOErrorTest
@@ -40,13 +41,13 @@ import java.io.PrintWriter
 private class Runner {
     companion object {
         val SSO_BASIC_TESTS = arrayOf(selectClass(PostSSOTest::class.java),
-            selectClass(RedirectSSOTest::class.java))
+                selectClass(RedirectSSOTest::class.java))
         val SSO_ERROR_TESTS = arrayOf(selectClass(RedirectSSOErrorTest::class.java),
-            selectClass(PostSSOErrorTest::class.java))
+                selectClass(PostSSOErrorTest::class.java))
         val SLO_BASIC_TESTS = arrayOf(selectClass(PostSLOTest::class.java),
-            selectClass(RedirectSLOTest::class.java))
+                selectClass(RedirectSLOTest::class.java))
         val SLO_ERROR_TESTS = arrayOf(selectClass(PostSLOErrorTest::class.java),
-            selectClass(RedirectSLOErrorTest::class.java))
+                selectClass(RedirectSLOErrorTest::class.java))
     }
 }
 
@@ -59,24 +60,29 @@ fun main(args: Array<String>) {
     parser.setApplicationDescription("SAML Conformance Test Kit")
 
     parser.option("i",
-        description = "Path to the implementation to be tested")
+            description = "Path to the implementation to be tested")
+
+    parser.option("u",
+            description = "User used to login in the format username:password.")
 
     parser.flag("d",
-        description = "Turn on debug logs.")
+            description = "Turn on debug logs.")
 
     parser.flag("l",
-        description = """When an error occurs, the SAML V2.0 Standard Specification requires an IdP
-            to respond with a 200 HTTP status code and a valid SAML response containing an error
-            <StatusCode>. If the -l flag is given, this test kit will allow HTTP error status codes
-            as a valid error response.
-            """)
+            description = """When an error occurs, the SAML V2.0 Standard Specification requires an
+                IdP to respond with a 200 HTTP status code and a valid SAML response containing an
+                error <StatusCode>. If the -l flag is given, this test kit will allow HTTP error
+                status codes as a valid error response.""")
 
     val arguments = parser.parse(args)
 
     val implementationPath = arguments.option("i")
-        ?: "$samlDist/implementations/ddf"
+            ?: "$samlDist/implementations/ddf"
+
+    val userLogin = arguments.option("i") ?: "admin:admin"
 
     System.setProperty(IMPLEMENTATION_PATH, implementationPath)
+    System.setProperty(USER_LOGIN, userLogin)
     System.setProperty(TEST_SP_METADATA_PROPERTY, "$samlDist/conf/samlconf-sp-metadata.xml")
     System.setProperty(LENIENT_ERROR_VERIFICATION, arguments.flag("l").toString())
 
@@ -92,11 +98,11 @@ fun main(args: Array<String>) {
 @Suppress("SpreadOperator")
 private fun launchTests() {
     val request = LauncherDiscoveryRequestBuilder.request()
-        .selectors(*SSO_BASIC_TESTS,
-            *SSO_ERROR_TESTS,
-            *SLO_BASIC_TESTS,
-            *SLO_ERROR_TESTS)
-        .build()
+            .selectors(*SSO_BASIC_TESTS,
+                    *SSO_ERROR_TESTS,
+                    *SLO_BASIC_TESTS,
+                    *SLO_ERROR_TESTS)
+            .build()
 
     val summaryGeneratingListener = SummaryGeneratingListener()
     LauncherFactory.create().apply {

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -32,6 +32,7 @@ import javax.xml.transform.TransformerFactory
 import kotlin.test.currentStackTrace
 
 const val IMPLEMENTATION_PATH = "implementation.path"
+const val USER_LOGIN = "user.login"
 const val TEST_SP_METADATA_PROPERTY = "test.sp.metadata"
 const val LENIENT_ERROR_VERIFICATION = "lenient.error.verification"
 
@@ -92,10 +93,10 @@ class Common {
          */
         fun getSingleLogoutLocation(binding: String): String? {
             return idpMetadataObject
-                .descriptor
-                ?.singleLogoutServices
-                ?.first { it.binding == binding }
-                ?.location
+                    .descriptor
+                    ?.singleLogoutServices
+                    ?.first { it.binding == binding }
+                    ?.location
         }
 
         /**


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Added `-u` option to the run script to provide username and password. 
This is used in logout tests since we provide a NameID with the user to sign out.

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified