### PR TITLE
MAINT - Modified SimpleSign to accept more SigAlgs when validating

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ project.ext {
     mockk_version = '1.7.15'
     junit_jupiter_version = '5.1.0'
     junit_platform_version = '1.1.1'
+    apache_wss4j_version='2.2.2'
+    apache_cxf_version='3.2.2'
 }
 
 allprojects {

--- a/ctk/common/build.gradle
+++ b/ctk/common/build.gradle
@@ -4,6 +4,8 @@ description = 'Common Functions for IdP Tests.'
 dependencies {
     compile project(':library')
     compile project(':external:samlconf-plugins-api')
+
+    compile "org.apache.wss4j:wss4j-ws-security-common:$apache_wss4j_version"
     testCompile "io.kotlintest:kotlintest-runner-junit5:$kotlin_test_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_jupiter_version"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,20 +2,9 @@ description = 'Common libraries from DDF for building request/response, signing 
 
 apply plugin: 'maven-publish'
 
-project.ext {
-    apache_wss4j_version='2.1.11'
-    apache_cxf_version='3.2.2'
-}
-
 dependencies {
-    compile "org.apache.wss4j:wss4j-ws-security-common:$apache_wss4j_version"
-    compile "org.apache.wss4j:wss4j-ws-security-dom:$apache_wss4j_version"
-    compile "org.apache.cxf:cxf-core:$apache_cxf_version"
     compile "org.apache.cxf:cxf-rt-rs-security-sso-saml:$apache_cxf_version"
-
-    compile 'org.opensaml:opensaml-saml-api:3.1.1'
     compile 'com.google.http-client:google-http-client:1.22.0'
-    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'org.keyczar:keyczar:0.66'
     compile 'net.sf.jtidy:jtidy:r938'
 


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Modified SimpleSign to accept more SigAlgs when validating.
Still uses `SHA1withRSA` or `SHA1withDSA` when signing

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified