### PR TITLE
MAINT - Fixing test issues that were discovered against Keycloak

### DIFF
--- a/ctk/common/src/main/java/org/codice/compliance/utils/sign/SimpleSign.java
+++ b/ctk/common/src/main/java/org/codice/compliance/utils/sign/SimpleSign.java
@@ -41,9 +41,6 @@ import org.apache.wss4j.common.saml.SAMLUtil;
 import org.apache.wss4j.dom.engine.WSSConfig;
 import org.apache.wss4j.dom.handler.RequestData;
 import org.apache.wss4j.dom.saml.WSSSAMLKeyInfoProcessor;
-import org.apache.wss4j.dom.validate.Credential;
-import org.apache.wss4j.dom.validate.SignatureTrustValidator;
-import org.apache.wss4j.dom.validate.Validator;
 import org.opensaml.saml.common.SAMLObjectContentReference;
 import org.opensaml.saml.common.SignableSAMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -279,17 +276,6 @@ public class SimpleSign {
     }
 
     validateSignatureAndSamlKey(signature, samlKeyInfo);
-
-    Credential trustCredential = new Credential();
-    trustCredential.setPublicKey(samlKeyInfo.getPublicKey());
-    trustCredential.setCertificates(samlKeyInfo.getCerts());
-    Validator signatureValidator = new SignatureTrustValidator();
-
-    try {
-      signatureValidator.validate(trustCredential, requestData);
-    } catch (WSSecurityException e) {
-      throw new SignatureException("Error validating signature", e);
-    }
   }
 
   private void validateSignatureAndSamlKey(Signature signature, SAMLKeyInfo samlKeyInfo)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/SLOCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/SLOCommon.kt
@@ -37,6 +37,7 @@ import org.codice.compliance.utils.TestCommon.Companion.useDefaultServiceProvide
 import org.codice.compliance.utils.TestCommon.Companion.username
 import org.codice.compliance.utils.sign.SimpleSign
 import org.codice.compliance.verification.binding.BindingVerifier.Companion.verifyHttpStatusCode
+import org.codice.compliance.verification.core.responses.CoreAuthnRequestProtocolVerifier
 import org.codice.security.saml.SamlProtocol
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.codice.security.saml.SamlProtocol.POST_BINDING
@@ -81,7 +82,9 @@ class SLOCommon {
                             .getResponseForPostRequest(firstLoginResponse)
                             .apply {
                                 GlobalSession.addCookies(cookies)
-                            }.getBindingVerifier().decodeAndVerify().node
+                            }.getBindingVerifier().decodeAndVerify().node.also {
+                        CoreAuthnRequestProtocolVerifier(authnRequest, NodeWrapper(it)).preProcess()
+                    }
 
                     if (multipleSP) {
                         useDSAServiceProvider()
@@ -94,7 +97,9 @@ class SLOCommon {
                             .getResponseForRedirectRequest(firstLoginResponse)
                             .apply {
                                 GlobalSession.addCookies(cookies)
-                            }.getBindingVerifier().decodeAndVerify().node
+                            }.getBindingVerifier().decodeAndVerify().node.also {
+                        CoreAuthnRequestProtocolVerifier(authnRequest, NodeWrapper(it)).preProcess()
+                    }
 
                     if (multipleSP) {
                         useDSAServiceProvider()

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -13,10 +13,6 @@
  */
 package org.codice.compliance.utils
 
-import io.kotlintest.TestCaseConfig
-import io.kotlintest.TestResult
-import io.kotlintest.extensions.TestCaseExtension
-import io.kotlintest.extensions.TestCaseInterceptContext
 import org.apache.cxf.helpers.DOMUtils
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_RESPONSE
@@ -90,16 +86,6 @@ class TestCommon {
 
         var currentSPEntityInfo by LazyVar {
             DEFAULT_SP_ENTITY_INFO
-        }
-
-        object UseDSASigningSP : TestCaseExtension {
-            override fun intercept(context: TestCaseInterceptContext,
-                                   test: (TestCaseConfig, (TestResult) -> Unit) -> Unit,
-                                   complete: (TestResult) -> Unit) {
-                useDSAServiceProvider()
-                test(context.config, { complete(it) })
-                useDefaultServiceProvider()
-            }
         }
 
         /**

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -124,7 +124,7 @@ abstract class CoreVerifier(private val samlNode: NodeWrapper) {
     open fun verifyEncryptedElements() {
     }
 
-    private fun preProcess(encVerifier: EncryptionVerifier = EncryptionVerifier()) {
+    fun preProcess(encVerifier: EncryptionVerifier = EncryptionVerifier()) {
         val encElements = retrieveCurrentEncryptedElements(node)
         if (encElements.isEmpty()) {
             Log.debugWithSupplier {

--- a/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
+++ b/ctk/idp/src/main/kotlin/io/kotlintest/provided/ProjectConfig.kt
@@ -15,19 +15,22 @@ package io.kotlintest.provided
 
 import de.jupf.staticlog.Log
 import io.kotlintest.AbstractProjectConfig
+import io.kotlintest.Description
 import io.kotlintest.Tag
+import io.kotlintest.TestResult
 import io.kotlintest.extensions.TestListener
 import io.restassured.RestAssured
 import io.restassured.RestAssured.config
 import io.restassured.config.RedirectConfig.redirectConfig
 import org.codice.compliance.Common
 import org.codice.compliance.utils.GlobalSession
+import org.codice.compliance.utils.TestCommon.Companion.useDefaultServiceProvider
 
 object SLO : Tag()
 object SSO : Tag()
 
 object ProjectConfig : AbstractProjectConfig() {
-    override fun listeners(): List<TestListener> = listOf(GlobalSession)
+    override fun listeners(): List<TestListener> = listOf(GlobalSession, SPReset)
 
     override fun beforeAll() {
         RestAssured.config = config().redirect(redirectConfig().followRedirects(false))
@@ -51,5 +54,11 @@ object ProjectConfig : AbstractProjectConfig() {
 
         System.setProperty("kotlintest.tags.exclude",
             setOfExclusions.joinToString(",", transform = { it.name }))
+    }
+}
+
+object SPReset : TestListener {
+    override fun afterTest(description: Description, testResult: TestResult) {
+        useDefaultServiceProvider()
     }
 }

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -24,10 +24,10 @@ import org.codice.compliance.utils.ENCRYPTED_ID
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.SSOCommon.Companion.createDefaultAuthnRequest
 import org.codice.compliance.utils.SSOCommon.Companion.sendRedirectAuthnRequest
-import org.codice.compliance.utils.TestCommon.Companion.UseDSASigningSP
 import org.codice.compliance.utils.TestCommon.Companion.currentSPIssuer
 import org.codice.compliance.utils.TestCommon.Companion.encodeRedirectRequest
 import org.codice.compliance.utils.TestCommon.Companion.getImplementation
+import org.codice.compliance.utils.TestCommon.Companion.useDSAServiceProvider
 import org.codice.compliance.utils.getBindingVerifier
 import org.codice.compliance.utils.sign.SimpleSign
 import org.codice.compliance.verification.binding.BindingVerifier
@@ -125,8 +125,8 @@ class RedirectSSOTest : StringSpec() {
             }
         }
 
-        "Bindings 3.4.4.1: Redirect AuthnRequest Using DSA1 Signature Algorithm".config(
-                extensions = listOf(UseDSASigningSP)) {
+        "Bindings 3.4.4.1: Redirect AuthnRequest Using DSA1 Signature Algorithm" {
+            useDSAServiceProvider()
             val authnRequest = createDefaultAuthnRequest(HTTP_REDIRECT)
             val encodedRequest = encodeRedirectRequest(authnRequest)
             val queryParams = SimpleSign().signUriString(


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
- Removed Trust validation from SimpleSign since we can't expect any third-party IdP to put its cert in our keystore
- Preprocess the authn response in SLO tests, so that it's decrypted for the `SubjectComparisonVerifier`
- Added TestListener that always sets back to the default SP

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified