### PR TITLE
MAINT - Modified SimpleSign to accept more SigAlgs when validating

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ project.ext {
     mockk_version = '1.7.15'
     junit_jupiter_version = '5.1.0'
     junit_platform_version = '1.1.1'
+    apache_wss4j_version='2.2.2'
+    apache_cxf_version='3.2.4'
 }
 
 allprojects {

--- a/ctk/common/build.gradle
+++ b/ctk/common/build.gradle
@@ -4,6 +4,8 @@ description = 'Common Functions for IdP Tests.'
 dependencies {
     compile project(':library')
     compile project(':external:samlconf-plugins-api')
+
+    compile "org.apache.wss4j:wss4j-ws-security-common:$apache_wss4j_version"
     testCompile "io.kotlintest:kotlintest-runner-junit5:$kotlin_test_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_jupiter_version"

--- a/ctk/common/src/main/java/org/codice/compliance/utils/sign/SimpleSign.java
+++ b/ctk/common/src/main/java/org/codice/compliance/utils/sign/SimpleSign.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.cxf.rs.security.saml.sso.SSOConstants;
+import org.apache.wss4j.common.WSS4JConstants;
 import org.apache.wss4j.common.crypto.CryptoType;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
@@ -41,6 +42,7 @@ import org.apache.wss4j.common.saml.SAMLUtil;
 import org.apache.wss4j.dom.engine.WSSConfig;
 import org.apache.wss4j.dom.handler.RequestData;
 import org.apache.wss4j.dom.saml.WSSSAMLKeyInfoProcessor;
+import org.apache.xml.security.algorithms.JCEMapper;
 import org.opensaml.saml.common.SAMLObjectContentReference;
 import org.opensaml.saml.common.SignableSAMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -53,21 +55,10 @@ import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureValidator;
 import org.opensaml.xmlsec.signature.support.provider.ApacheSantuarioSignatureValidationProviderImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SimpleSign {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SimpleSign.class);
-
   private final SystemCrypto crypto;
-
-  private static final Map<String, String> URI_ALG_MAP = new HashMap<>();
-
-  static {
-    URI_ALG_MAP.put("http://www.w3.org/2000/09/xmldsig#dsa-sha1", "SHA1withDSA");
-    URI_ALG_MAP.put("http://www.w3.org/2000/09/xmldsig#rsa-sha1", "SHA1withRSA");
-  }
 
   public SimpleSign() throws IOException {
     crypto = new SystemCrypto(getCurrentSPHostname());
@@ -221,10 +212,9 @@ public class SimpleSign {
       String signature = URLDecoder.decode(encodedSignature, StandardCharsets.UTF_8.name());
 
       CertificateFactory certificateFactory = CertificateFactory.getInstance("X509");
-      Certificate certificate;
-      certificate = getCertificate(certificateString, certificateFactory);
+      Certificate certificate = getCertificate(certificateString, certificateFactory);
 
-      String jceSigAlg = URI_ALG_MAP.get(sigAlg);
+      String jceSigAlg = JCEMapper.translateURItoJCEID(sigAlg);
 
       if (jceSigAlg == null) {
         throw new SignatureException(SignatureException.SigErrorCode.INVALID_URI);
@@ -313,36 +303,22 @@ public class SimpleSign {
   /** Private Getters */
   private java.security.Signature getSignature(X509Certificate certificate, PrivateKey privateKey)
       throws SignatureException {
-    String jceSigAlgo = "SHA1withRSA";
-    if ("DSA".equalsIgnoreCase(certificate.getPublicKey().getAlgorithm())) {
-      jceSigAlgo = "SHA1withDSA";
-    }
 
     java.security.Signature signature;
     try {
+      String jceSigAlgo = String.format("SHA1with%s", certificate.getPublicKey().getAlgorithm());
       signature = java.security.Signature.getInstance(jceSigAlgo);
-    } catch (NoSuchAlgorithmException e) {
-      throw new SignatureException(e);
-    }
-    try {
       signature.initSign(privateKey);
-    } catch (InvalidKeyException e) {
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
       throw new SignatureException(e);
     }
     return signature;
   }
 
   private String getSignatureAlgorithm(X509Certificate certificate) {
-    String sigAlgo = SSOConstants.RSA_SHA1;
-    String pubKeyAlgo = certificate.getPublicKey().getAlgorithm();
-
-    if (pubKeyAlgo.equalsIgnoreCase("DSA")) {
-      sigAlgo = SSOConstants.DSA_SHA1;
-    }
-
-    LOGGER.debug("Using Signature algorithm {}", sigAlgo);
-
-    return sigAlgo;
+    return certificate.getPublicKey().getAlgorithm().equals("RSA")
+        ? WSS4JConstants.RSA
+        : WSS4JConstants.DSA;
   }
 
   private X509Certificate[] getSignatureCertificates() throws SignatureException {
@@ -404,21 +380,19 @@ public class SimpleSign {
 
     private SigErrorCode sigErrorCode;
 
-    public SignatureException() {}
-
-    public SignatureException(Throwable cause) {
+    SignatureException(Throwable cause) {
       super(cause);
     }
 
-    public SignatureException(String message) {
+    SignatureException(String message) {
       super(message);
     }
 
-    public SignatureException(String message, Throwable cause) {
+    SignatureException(String message, Throwable cause) {
       super(message, cause);
     }
 
-    public SignatureException(SigErrorCode sigErrorCode) {
+    SignatureException(SigErrorCode sigErrorCode) {
       super();
       setErrorCode(sigErrorCode);
     }
@@ -427,7 +401,7 @@ public class SimpleSign {
       return sigErrorCode;
     }
 
-    public void setErrorCode(SigErrorCode sigErrorCode) {
+    void setErrorCode(SigErrorCode sigErrorCode) {
       this.sigErrorCode = sigErrorCode;
     }
   }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,20 +2,9 @@ description = 'Common libraries from DDF for building request/response, signing 
 
 apply plugin: 'maven-publish'
 
-project.ext {
-    apache_wss4j_version='2.1.11'
-    apache_cxf_version='3.2.2'
-}
-
 dependencies {
-    compile "org.apache.wss4j:wss4j-ws-security-common:$apache_wss4j_version"
-    compile "org.apache.wss4j:wss4j-ws-security-dom:$apache_wss4j_version"
-    compile "org.apache.cxf:cxf-core:$apache_cxf_version"
     compile "org.apache.cxf:cxf-rt-rs-security-sso-saml:$apache_cxf_version"
-
-    compile 'org.opensaml:opensaml-saml-api:3.1.1'
     compile 'com.google.http-client:google-http-client:1.22.0'
-    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'org.keyczar:keyczar:0.66'
     compile 'net.sf.jtidy:jtidy:r938'
 


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.

### NOTE: Identical PR to https://github.com/connexta/saml-conformance/pull/168

Modified SimpleSign to accept more SigAlgs when validating.
Still uses `SHA1withRSA` or `SHA1withDSA` when signing

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified