### PR TITLE
MAINT - Adding mechanism to enable/disable verifications/tests if running against DDF

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SubjectComparisonVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SubjectComparisonVerifier.kt
@@ -14,6 +14,7 @@
 package org.codice.compliance.verification.core
 
 import com.google.common.collect.Sets
+import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_3_4_b
 import org.codice.compliance.SAMLCore_3_3_4_c
@@ -108,7 +109,8 @@ class SubjectComparisonVerifier(private val samlResponseDom: Node) {
                 "Could not find the logout request's identifier.")
 
         // Not handled correctly by DDF, so temporarily disabling this. See DDF-3951.
-        // verifyIdAttributesMatch(assertionId, logoutRequestId, SAMLProfiles_4_4_4_1_c)
+        if (!runningAgainstDDF())
+            verifyIdAttributesMatch(assertionId, logoutRequestId, SAMLProfiles_4_4_4_1_c)
         verifyIdContentsMatch(assertionId, logoutRequestId, SAMLProfiles_4_4_4_1_c)
     }
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
@@ -14,6 +14,7 @@
 package org.codice.compliance.verification.core.responses
 
 import io.restassured.response.Response
+import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_4_1_4_a
 import org.codice.compliance.SAMLCore_3_4_1_4_b
@@ -54,7 +55,8 @@ class CoreAuthnRequestProtocolVerifier(private val authnRequest: AuthnRequest,
         verifyAuthnRequestProtocolResponse()
         verifySubjects()
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy, uncomment this line
-        //        nameIdPolicyVerifier?.apply { verify() }
+        if (!runningAgainstDDF())
+            nameIdPolicyVerifier?.apply { verify() }
     }
 
     fun verifyAssertionConsumerService(httpResponse: Response) {

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
@@ -56,7 +56,7 @@ class CoreAuthnRequestProtocolVerifier(private val authnRequest: AuthnRequest,
         verifySubjects()
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy, uncomment this line
         if (!runningAgainstDDF())
-            nameIdPolicyVerifier?.apply { verify() }
+            nameIdPolicyVerifier?.verify()
     }
 
     fun verifyAssertionConsumerService(httpResponse: Response) {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -18,6 +18,7 @@ import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.wss4j.common.saml.builder.SAML2Constants
+import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.saml.plugin.IdpSSOResponder
 import org.codice.compliance.utils.ENCRYPTED_ID
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
@@ -108,7 +109,8 @@ class PostSSOTest : StringSpec() {
 
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
-        "POST AuthnRequest With Email NameIDPolicy Format Test".config(enabled = false) {
+        "POST AuthnRequest With Email NameIDPolicy Format Test".config(
+                enabled = !runningAgainstDDF()) {
             val authnRequest = createDefaultAuthnRequest(HTTP_POST).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = SAML2Constants.NAMEID_FORMAT_EMAIL_ADDRESS
@@ -137,7 +139,8 @@ class PostSSOTest : StringSpec() {
 
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
-        "POST AuthnRequest With Encrypted NameIDPolicy Format Test".config(enabled = false) {
+        "POST AuthnRequest With Encrypted NameIDPolicy Format Test".config(
+                enabled = !runningAgainstDDF()) {
             val authnRequest = createDefaultAuthnRequest(HTTP_POST).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = ENCRYPTED_ID

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -19,6 +19,7 @@ import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
 import org.apache.wss4j.common.saml.builder.SAML2Constants
+import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.saml.plugin.IdpSSOResponder
 import org.codice.compliance.utils.ENCRYPTED_ID
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
@@ -154,7 +155,8 @@ class RedirectSSOTest : StringSpec() {
 
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
-        "Redirect AuthnRequest With Email NameID Format Test".config(enabled = false) {
+        "Redirect AuthnRequest With Email NameID Format Test".config(
+                enabled = !runningAgainstDDF()) {
             val authnRequest = createDefaultAuthnRequest(HTTP_REDIRECT).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = SAML2Constants.NAMEID_FORMAT_EMAIL_ADDRESS
@@ -189,7 +191,8 @@ class RedirectSSOTest : StringSpec() {
 
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
-        "Redirect AuthnRequest With Encrypted NameID Format Test".config(enabled = false) {
+        "Redirect AuthnRequest With Encrypted NameID Format Test".config(
+                enabled = !runningAgainstDDF()) {
             val authnRequest = createDefaultAuthnRequest(HTTP_REDIRECT).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = ENCRYPTED_ID

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
@@ -17,6 +17,7 @@ import io.kotlintest.TestCaseConfig
 import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
+import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
 import org.codice.compliance.SAMLBindings_3_5_3_a
 import org.codice.compliance.SAMLComplianceException
@@ -89,7 +90,7 @@ class PostSSOErrorTest : StringSpec() {
 
         // TODO - DDF responds with a successful response. Re-enable test when DDF handles this
         "Profiles 4.1.4.1: POST AuthnRequest With Subject Containing an Invalid Name ID Test"
-            .config(enabled = false) {
+            .config(enabled = !runningAgainstDDF()) {
                 try {
                     val authnRequest =
                         createDefaultAuthnRequest(HTTP_POST).apply {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
@@ -18,6 +18,7 @@ import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
+import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
 import org.codice.compliance.SAMLBindings_3_4_3_a
 import org.codice.compliance.SAMLComplianceException
@@ -122,7 +123,7 @@ class RedirectSSOErrorTest : StringSpec() {
 
         // TODO - DDF responds with a successful response. Re-enable test when DDF handles this
         "Profiles 4.1.4.1: Redirect AuthnRequest With Subject Containing an Invalid Name ID Test"
-                .config(enabled = false) {
+                .config(enabled = !runningAgainstDDF()) {
                 try {
                     val authnRequest =
                         createDefaultAuthnRequest(HTTP_REDIRECT).apply {

--- a/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
+++ b/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
@@ -15,6 +15,7 @@ package org.codice.ctk
 
 import de.jupf.staticlog.Log
 import de.jupf.staticlog.core.LogLevel
+import org.codice.compliance.DEFAULT_IMPLEMENTATION_PATH
 import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
 import org.codice.compliance.TEST_SP_METADATA_PROPERTY
@@ -77,7 +78,7 @@ fun main(args: Array<String>) {
     val arguments = parser.parse(args)
 
     val implementationPath = arguments.option("i")
-            ?: "$samlDist/implementations/ddf"
+            ?: "$samlDist/$DEFAULT_IMPLEMENTATION_PATH"
 
     val userLogin = arguments.option("i") ?: "admin:admin"
 

--- a/external/implementations/samlconf-ddf-impl/README.md
+++ b/external/implementations/samlconf-ddf-impl/README.md
@@ -1,4 +1,11 @@
 # The [DDF](https://github.com/codice/ddf) SAML Implementation
+## Known Compliance Issues
+| Issue                                                                                           | Section          | Specification Snippet
+| ---------------------------------------------------------------------------------------------------------------------- | ---------------- | -----------------------
+| When the IdP is issuing LogoutRequests to SPs, the NameID is missing all of its XML attributes                         | Profiles 4.4.4.1 | The principal MUST be identified in the request using an identifier that strongly matches the identifier in the authentication assertion the requester issued or received regarding the session being terminated, per the matching rules defined in Section 3.3.4 of [SAMLCore].
+| In the Response, NameIDs do not have the format or the SPNameQualifier specified in the AuthnRequest's NameIDPolicy    | Core 3.4.1.1     | When a Format defined in Section 8.3 other than urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified or urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted is used, then if the identity provider returns any assertions: the Format value of the \<NameID> within the \<Subject> of any \<Assertion> MUST be identical to the Format value supplied in the \<NameIDPolicy> and if SPNameQualifier is not omitted in \<NameIDPolicy>, the SPNameQualifier value of the \<NameID> within the \<Subject> of any \<Assertion> MUST be identical to the SPNameQualifier value supplied in the \<NameIDPolicy>.
+| The IdP ignores the \<Subject> element on the \<AuthnRequest> instead of validating it                                 | Profiles 4.1.4.1 | Note that the service provider MAY include a \<Subject> element in the request that names the actual identity about which it wishes to receive an assertion. This element MUST NOT contain any \<SubjectConfirmation> elements. If the identity provider does not recognize the principal as that identity, then it MUST respond with a \<Response> message containing an error status and no assertions.
+
 
 ## Steps to Test DDF's IDP
 * Start and install DDF

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -32,6 +32,7 @@ import javax.xml.transform.TransformerFactory
 import kotlin.test.currentStackTrace
 
 const val IMPLEMENTATION_PATH = "implementation.path"
+const val DEFAULT_IMPLEMENTATION_PATH = "implementations/ddf"
 const val USER_LOGIN = "user.login"
 const val TEST_SP_METADATA_PROPERTY = "test.sp.metadata"
 const val LENIENT_ERROR_VERIFICATION = "lenient.error.verification"
@@ -125,6 +126,9 @@ class Common {
                 }
             }
         }
+
+        fun runningAgainstDDF() = System.getProperty(IMPLEMENTATION_PATH).contains(
+                DEFAULT_IMPLEMENTATION_PATH)
     }
 }
 


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
See title.
#### Checklist:
- [X] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified