### PR TITLE
MAINT - Turned NodeWrapper into NodeDecorator

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/SLOCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/SLOCommon.kt
@@ -82,9 +82,10 @@ class SLOCommon {
                             .getResponseForPostRequest(firstLoginResponse)
                             .apply {
                                 GlobalSession.addCookies(cookies)
-                            }.getBindingVerifier().decodeAndVerify().node.also {
-                        CoreAuthnRequestProtocolVerifier(authnRequest, NodeWrapper(it)).preProcess()
-                    }
+                            }.getBindingVerifier().decodeAndVerify().also {
+                                CoreAuthnRequestProtocolVerifier(authnRequest,
+                                        it).preProcess()
+                            }
 
                     if (multipleSP) {
                         useDSAServiceProvider()
@@ -97,9 +98,10 @@ class SLOCommon {
                             .getResponseForRedirectRequest(firstLoginResponse)
                             .apply {
                                 GlobalSession.addCookies(cookies)
-                            }.getBindingVerifier().decodeAndVerify().node.also {
-                        CoreAuthnRequestProtocolVerifier(authnRequest, NodeWrapper(it)).preProcess()
-                    }
+                            }.getBindingVerifier().decodeAndVerify().also {
+                                CoreAuthnRequestProtocolVerifier(authnRequest,
+                                        it).preProcess()
+                            }
 
                     if (multipleSP) {
                         useDSAServiceProvider()

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -21,6 +21,7 @@ import org.apache.wss4j.common.util.DOM2Writer
 import org.codice.compliance.Common.Companion.idpMetadataObject
 import org.codice.compliance.Common.Companion.parseSpMetadata
 import org.codice.compliance.IMPLEMENTATION_PATH
+import org.codice.compliance.DecoratedNode
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLGeneral_c
 import org.codice.compliance.USER_LOGIN
@@ -215,5 +216,9 @@ class LazyVar<T>(val init: () -> T) : ReadWriteProperty<Any?, T> {
     }
 }
 
-data class NodeWrapper(val node: Node, var hasEncryptedAssertion: Boolean = false,
-                       var isSigned: Boolean = false)
+class NodeDecorator(private val node: Node, var hasEncryptedAssertion: Boolean = false,
+                    var isSigned: Boolean = false) : DecoratedNode, Node by node {
+    override fun getNode(): Node {
+        return node
+    }
+}

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/BindingVerifier.kt
@@ -18,7 +18,7 @@ import org.apache.wss4j.common.saml.OpenSAMLUtil
 import org.codice.compliance.SAMLBindings_3_4_6_a
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLGeneral_b
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.RESPONSE
 import org.codice.compliance.utils.sign.SimpleSign
 import org.opensaml.saml.saml2.core.RequestAbstractType
@@ -86,5 +86,5 @@ abstract class BindingVerifier(val httpResponse: Response) {
     var isSamlRequest: Boolean = false
     var isRelayStateGiven: Boolean = false
     abstract fun decodeAndVerifyError(): Node
-    abstract fun decodeAndVerify(): NodeWrapper
+    abstract fun decodeAndVerify(): NodeDecorator
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/PostBindingVerifier.kt
@@ -26,7 +26,7 @@ import org.codice.compliance.debugPrettyPrintXml
 import org.codice.compliance.recursiveChildren
 import org.codice.compliance.utils.ASSERTION
 import org.codice.compliance.utils.DESTINATION
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.TestCommon.Companion.getServiceUrl
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.codice.security.sign.Decoder
@@ -35,16 +35,16 @@ import kotlin.test.assertNotNull
 
 class PostBindingVerifier(httpResponse: Response) : BindingVerifier(httpResponse) {
     /** Verify the response for a post binding */
-    override fun decodeAndVerify(): NodeWrapper {
+    override fun decodeAndVerify(): NodeDecorator {
         val samlResponseString =
                 PostFormVerifier(httpResponse, isRelayStateGiven, isSamlRequest).verifyAndParse()
         val samlResponseDom = decode(samlResponseString)
-        val nodeWrapper = NodeWrapper(samlResponseDom).apply {
-            isSigned = verifyXmlSignatures(samlResponseDom)
+        val nodeDecorator = NodeDecorator(samlResponseDom).apply {
+            isSigned = verifyXmlSignatures(this)
         }
-        verifyPostSSO(samlResponseDom)
-        verifyPostDestination(samlResponseDom)
-        return nodeWrapper
+        verifyPostSSO(nodeDecorator)
+        verifyPostDestination(nodeDecorator)
+        return nodeDecorator
     }
 
     /** Verify an error response (Negative path) */

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/binding/RedirectBindingVerifier.kt
@@ -45,7 +45,7 @@ import org.codice.compliance.utils.DESTINATION
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.LOCATION
 import org.codice.compliance.utils.MAX_RELAY_STATE_LEN
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.SAML_ENCODING
 import org.codice.compliance.utils.TestCommon.Companion.getServiceUrl
 import org.codice.compliance.utils.TestCommon.Companion.idpMetadata
@@ -71,21 +71,21 @@ import java.nio.charset.StandardCharsets
 class RedirectBindingVerifier(httpResponse: Response) : BindingVerifier(httpResponse) {
 
     /** Verify the response for a redirect binding */
-    override fun decodeAndVerify(): NodeWrapper {
+    override fun decodeAndVerify(): NodeDecorator {
         verifyHttpRedirectStatusCode()
         val paramMap = verifyNoNullsAndParse()
         verifyRedirectRelayState(paramMap[RELAY_STATE])
         val samlResponseDom = decode(paramMap)
         verifyNoXMLSig(samlResponseDom)
         verifyXmlSignatures(samlResponseDom) // Should verify assertions signature
-        val nodeWrapper = NodeWrapper(samlResponseDom)
+        val nodeDecorator = NodeDecorator(samlResponseDom)
         paramMap[SIGNATURE]?.let {
             verifyRedirectSignature(paramMap)
-            verifyRedirectDestination(samlResponseDom)
-            nodeWrapper.isSigned = true
+            verifyRedirectDestination(nodeDecorator)
+            nodeDecorator.isSigned = true
         }
 
-        return nodeWrapper
+        return nodeDecorator
     }
 
     /** Verify an error response (Negative path) */

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/CoreVerifier.kt
@@ -25,7 +25,7 @@ import org.codice.compliance.children
 import org.codice.compliance.debugWithSupplier
 import org.codice.compliance.prettyPrintXml
 import org.codice.compliance.recursiveChildren
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.REQUESTER
 import org.codice.compliance.utils.STATUS
 import org.codice.compliance.utils.STATUS_CODE
@@ -35,7 +35,7 @@ import org.codice.compliance.verification.core.CommonDataTypeVerifier.Companion.
 import org.w3c.dom.Node
 import java.time.Instant
 
-abstract class CoreVerifier(private val samlNode: NodeWrapper) {
+abstract class CoreVerifier(private val samlNode: NodeDecorator) {
     companion object {
         /**
          * Verifies that a response has the expected status code.
@@ -107,28 +107,26 @@ abstract class CoreVerifier(private val samlNode: NodeWrapper) {
         }
     }
 
-    private val node = samlNode.node
-
     /**
      * Verify response against the Core Spec document
      */
     open fun verify() {
         preProcess()
-        verifyCommonDataType(node)
-        SamlAssertionsVerifier(node).verify()
-        SamlVersioningVerifier(node).verify()
-        SignatureSyntaxAndProcessingVerifier(node).verify()
-        SamlDefinedIdentifiersVerifier(node).verify()
+        verifyCommonDataType(samlNode)
+        SamlAssertionsVerifier(samlNode).verify()
+        SamlVersioningVerifier(samlNode).verify()
+        SignatureSyntaxAndProcessingVerifier(samlNode).verify()
+        SamlDefinedIdentifiersVerifier(samlNode).verify()
     }
 
     open fun verifyEncryptedElements() {
     }
 
     fun preProcess(encVerifier: EncryptionVerifier = EncryptionVerifier()) {
-        val encElements = retrieveCurrentEncryptedElements(node)
+        val encElements = retrieveCurrentEncryptedElements(samlNode)
         if (encElements.isEmpty()) {
             Log.debugWithSupplier {
-                "Decrypted SAML Response:\n\n ${node.prettyPrintXml()}"
+                "Decrypted SAML Response:\n\n ${samlNode.prettyPrintXml()}"
             }
             return
         }
@@ -138,7 +136,7 @@ abstract class CoreVerifier(private val samlNode: NodeWrapper) {
                     " on the SAML Response."
         }
 
-        SchemaValidator.validateSAMLMessage(node)
+        SchemaValidator.validateSAMLMessage(samlNode)
         verifyEncryptedElements()
 
         if (encElements.any { it.localName == "EncryptedAssertion" })

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/RequestVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/RequestVerifier.kt
@@ -22,16 +22,14 @@ import org.codice.compliance.attributeNode
 import org.codice.compliance.utils.CONSENT
 import org.codice.compliance.utils.DESTINATION
 import org.codice.compliance.utils.ID
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.TestCommon.Companion.getServiceUrl
 import org.codice.compliance.utils.VERSION
 import org.codice.security.saml.SamlProtocol
 
-abstract class RequestVerifier(samlRequest: NodeWrapper,
+abstract class RequestVerifier(private val samlRequest: NodeDecorator,
                                private val binding: SamlProtocol.Binding)
     : CoreVerifier(samlRequest) {
-
-    private val samlRequestDom = samlRequest.node
 
     /** 3.2.1 Complex Type RequestAbstractType */
     override fun verify() {
@@ -42,26 +40,26 @@ abstract class RequestVerifier(samlRequest: NodeWrapper,
     /** All SAML requests are of types that are derived from the abstract RequestAbstractType
      * complex type. */
     private fun verifyRequestAbstractType() {
-        CommonDataTypeVerifier.verifyIdValue(samlRequestDom.attributeNode(ID), SAMLCore_3_2_1_a)
-        CommonDataTypeVerifier.verifyStringValue(samlRequestDom.attributeNode(VERSION),
+        CommonDataTypeVerifier.verifyIdValue(samlRequest.attributeNode(ID), SAMLCore_3_2_1_a)
+        CommonDataTypeVerifier.verifyStringValue(samlRequest.attributeNode(VERSION),
                 SAMLCore_3_2_1_b)
         CommonDataTypeVerifier.verifyDateTimeValue(
-                samlRequestDom.attributeNode("IssueInstant"), SAMLCore_3_2_1_c)
+                samlRequest.attributeNode("IssueInstant"), SAMLCore_3_2_1_c)
 
-        samlRequestDom.attributeNode(DESTINATION)?.apply {
+        samlRequest.attributeNode(DESTINATION)?.apply {
 
-            val url = getServiceUrl(binding, samlRequestDom)
+            val url = getServiceUrl(binding, samlRequest)
             if (textContent != url)
                 throw SAMLComplianceException.createWithPropertyMessage(SAMLCore_3_2_1_e,
                         property = DESTINATION,
                         actual = textContent,
                         expected = url,
-                        node = samlRequestDom)
+                        node = samlRequest)
 
             CommonDataTypeVerifier.verifyUriValue(this)
         }
 
-        samlRequestDom.attributeNode(CONSENT)?.let {
+        samlRequest.attributeNode(CONSENT)?.let {
             CommonDataTypeVerifier.verifyUriValue(it)
         }
     }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/CoreLogoutRequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/requests/CoreLogoutRequestProtocolVerifier.kt
@@ -17,16 +17,14 @@ import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_7_1_a
 import org.codice.compliance.SAMLCore_3_7_3_2_e
 import org.codice.compliance.attributeNode
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.verification.core.CommonDataTypeVerifier
 import org.codice.compliance.verification.core.RequestVerifier
 import org.codice.security.saml.SamlProtocol
 
-class CoreLogoutRequestProtocolVerifier(private val samlRequest: NodeWrapper,
+class CoreLogoutRequestProtocolVerifier(private val samlRequest: NodeDecorator,
                                         binding: SamlProtocol.Binding)
     : RequestVerifier(samlRequest, binding) {
-
-    private val samlRequestDom = samlRequest.node
 
     /** 3.7.1 Element <LogoutRequest>*/
     override fun verify() {
@@ -35,14 +33,14 @@ class CoreLogoutRequestProtocolVerifier(private val samlRequest: NodeWrapper,
     }
 
     private fun verifyLogoutRequest() {
-        samlRequestDom.attributeNode("Reason")?.let {
+        samlRequest.attributeNode("Reason")?.let {
             CommonDataTypeVerifier.verifyUriValue(it, SAMLCore_3_7_1_a)
         }
 
-        val notOnOrAfter = samlRequestDom.attributeNode("NotOnOrAfter")
+        val notOnOrAfter = samlRequest.attributeNode("NotOnOrAfter")
                 ?: throw SAMLComplianceException.create(SAMLCore_3_7_3_2_e,
                         message = "The attribute NotOnOrAfter was not found.",
-                        node = samlRequestDom)
+                        node = samlRequest)
 
         CommonDataTypeVerifier.verifyDateTimeValue(notOnOrAfter)
     }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreLogoutResponseProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreLogoutResponseProtocolVerifier.kt
@@ -18,7 +18,7 @@ import org.codice.compliance.SAMLCore_3_7_3_2_b
 import org.codice.compliance.SAMLCore_3_7_3_2_d
 import org.codice.compliance.attributeText
 import org.codice.compliance.children
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.STATUS
 import org.codice.compliance.utils.STATUS_CODE
 import org.codice.compliance.verification.core.ResponseVerifier
@@ -26,12 +26,10 @@ import org.codice.security.saml.SamlProtocol
 import org.opensaml.saml.saml2.core.LogoutRequest
 
 class CoreLogoutResponseProtocolVerifier(logoutRequest: LogoutRequest,
-                                         samlResponse: NodeWrapper,
+                                         private val samlResponse: NodeDecorator,
                                          binding: SamlProtocol.Binding,
                                          private val expectedSecondLevelStatusCode: String? = null)
     : ResponseVerifier(logoutRequest, samlResponse, binding) {
-
-    private val samlResponseDom = samlResponse.node
 
     override fun verify() {
         super.verify()
@@ -39,7 +37,7 @@ class CoreLogoutResponseProtocolVerifier(logoutRequest: LogoutRequest,
     }
 
     private fun verifySecondaryStatusCode() {
-        val secondaryStatusCode = samlResponseDom.children(STATUS)
+        val secondaryStatusCode = samlResponse.children(STATUS)
                 .flatMap { it.children(STATUS_CODE) }
                 .firstOrNull()
                 ?.children(STATUS_CODE)
@@ -51,6 +49,6 @@ class CoreLogoutResponseProtocolVerifier(logoutRequest: LogoutRequest,
             throw SAMLComplianceException.create(SAMLCore_3_7_3_2_b,
                     SAMLCore_3_7_3_2_d,
                     message = "The status code of $expectedSecondLevelStatusCode was not found",
-                    node = samlResponseDom)
+                    node = samlResponse)
     }
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleLogoutProfileVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleLogoutProfileVerifier.kt
@@ -22,12 +22,11 @@ import org.codice.compliance.SAMLProfiles_4_4_4_2_a
 import org.codice.compliance.SAMLProfiles_4_4_4_2_b
 import org.codice.compliance.utils.LOGOUT_REQUEST
 import org.codice.compliance.utils.LOGOUT_RESPONSE
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.verification.core.SubjectComparisonVerifier
 import org.w3c.dom.Node
 
-class SingleLogoutProfileVerifier(private val samlLogoutNodeWrapper: NodeWrapper) {
-    private val samlLogoutNode = samlLogoutNodeWrapper.node
+class SingleLogoutProfileVerifier(private val samlLogoutNode: NodeDecorator) {
 
     fun verifyLogoutRequest(ssoResponseDom: Node) {
         if (samlLogoutNode.localName != LOGOUT_REQUEST)
@@ -36,7 +35,7 @@ class SingleLogoutProfileVerifier(private val samlLogoutNodeWrapper: NodeWrapper
                             "session participants.",
                     node = samlLogoutNode)
 
-        if (!samlLogoutNodeWrapper.isSigned)
+        if (!samlLogoutNode.isSigned)
             throw SAMLComplianceException.create(SAMLProfiles_4_4_4_1_b,
                     message = "The Logout Request was not signed.",
                     node = samlLogoutNode)
@@ -53,7 +52,7 @@ class SingleLogoutProfileVerifier(private val samlLogoutNodeWrapper: NodeWrapper
                             "session participant.",
                     node = samlLogoutNode)
 
-        if (!samlLogoutNodeWrapper.isSigned)
+        if (!samlLogoutNode.isSigned)
             throw SAMLComplianceException.create(SAMLProfiles_4_4_4_2_b,
                     message = "The Logout Response was not signed.",
                     node = samlLogoutNode)

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/profile/SingleSignOnProfileVerifier.kt
@@ -21,7 +21,7 @@ import org.codice.compliance.SAMLProfiles_4_1_4_2_b
 import org.codice.compliance.SAMLProfiles_4_1_4_2_c
 import org.codice.compliance.children
 import org.codice.compliance.utils.ASSERTION
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.determineBinding
 import org.codice.compliance.verification.core.SubjectComparisonVerifier
 import org.codice.compliance.verification.profile.ProfilesVerifier.Companion.verifyIssuer
@@ -29,19 +29,17 @@ import org.codice.compliance.verification.profile.subject.confirmations.BearerSu
 import org.codice.compliance.verification.profile.subject.confirmations.HolderOfKeySubjectConfirmationVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
 
-class SingleSignOnProfileVerifier(private val response: NodeWrapper) {
-
-    private val samlResponseDom = response.node
+class SingleSignOnProfileVerifier(private val response: NodeDecorator) {
 
     /** 4.1.4.2 <Response> Usage */
     fun verify() {
         if (response.isSigned || response.hasEncryptedAssertion)
-            verifyIssuer(samlResponseDom, SAMLProfiles_4_1_4_2_a)
+            verifyIssuer(response, SAMLProfiles_4_1_4_2_a)
 
         verifySSOAssertions()
-        SubjectComparisonVerifier(samlResponseDom).verifySubjectsMatchSSO()
-        BearerSubjectConfirmationVerifier(samlResponseDom).verify()
-        HolderOfKeySubjectConfirmationVerifier(samlResponseDom).verify()
+        SubjectComparisonVerifier(response).verifySubjectsMatchSSO()
+        BearerSubjectConfirmationVerifier(response).verify()
+        HolderOfKeySubjectConfirmationVerifier(response).verify()
     }
 
     /** 4.1.2 Profile Overview */
@@ -54,11 +52,11 @@ class SingleSignOnProfileVerifier(private val response: NodeWrapper) {
 
     /** 4.1.4.2 <Response> Usage */
     private fun verifySSOAssertions() {
-        val assertions = samlResponseDom.children(ASSERTION)
+        val assertions = response.children(ASSERTION)
         if (assertions.isEmpty()) {
             throw SAMLComplianceException.create(SAMLProfiles_4_1_4_2_b,
                     message = "No Assertions found.",
-                    node = samlResponseDom)
+                    node = response)
         }
         assertions.forEach { verifyIssuer(it, SAMLProfiles_4_1_4_2_c) }
     }

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/RequestVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/RequestVerifierSpec.kt
@@ -30,7 +30,7 @@ import org.codice.compliance.SAMLCore_3_2_1_e
 import org.codice.compliance.TEST_SP_METADATA_PROPERTY
 import org.codice.compliance.utils.CONSENT
 import org.codice.compliance.utils.DESTINATION
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.verification.core.RequestVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import java.time.Instant
@@ -44,17 +44,17 @@ class RequestVerifierSpec : StringSpec() {
                 Resources.getResource("test-sp-metadata.xml").path)
 
         "request with correct ID, version and instant should pass" {
-            NodeWrapper(Common.buildDom(createRequest())).let {
+            NodeDecorator(Common.buildDom(createRequest())).let {
                 RequestVerifierTest(it).verify()
             }
         }
 
         "request with non-unique ID should fail" {
-            NodeWrapper(Common.buildDom(createRequest(id = "id"))).let {
+            NodeDecorator(Common.buildDom(createRequest(id = "id"))).let {
                 RequestVerifierTest(it).verify()
             }
 
-            NodeWrapper(Common.buildDom(createRequest(id = "id"))).let {
+            NodeDecorator(Common.buildDom(createRequest(id = "id"))).let {
                 shouldThrow<SAMLComplianceException> {
                     RequestVerifierTest(it).verify()
                 }.message?.apply {
@@ -65,7 +65,7 @@ class RequestVerifierSpec : StringSpec() {
         }
 
         "request with incorrect version (empty) should fail" {
-            NodeWrapper(Common.buildDom(createRequest(version = ""))).let {
+            NodeDecorator(Common.buildDom(createRequest(version = ""))).let {
                 shouldThrow<SAMLComplianceException> {
                     RequestVerifierTest(it).verify()
                 }.message?.apply {
@@ -76,7 +76,7 @@ class RequestVerifierSpec : StringSpec() {
         }
 
         "request with incorrect instant (non-UTC) should fail" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createRequest(instant = "2018-05-01T06:15:30-07:00"))).let {
                 shouldThrow<SAMLComplianceException> {
                     RequestVerifierTest(it).verify()
@@ -88,14 +88,14 @@ class RequestVerifierSpec : StringSpec() {
         }
 
         "request with correct destination should pass" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createRequest(attribute = "$DESTINATION=\"$correctUri\""))).let {
                 RequestVerifierTest(it).verify()
             }
         }
 
         "request with incorrect destination should fail" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createRequest(attribute = "$DESTINATION=\"$incorrectUri\""))).let {
                 shouldThrow<SAMLComplianceException> {
                     RequestVerifierTest(it).verify()
@@ -104,14 +104,14 @@ class RequestVerifierSpec : StringSpec() {
         }
 
         "request with correct consent should pass" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createRequest(attribute = "$CONSENT=\"$correctUri\""))).let {
                 RequestVerifierTest(it).verify()
             }
         }
 
         "request with incorrect consent (relative URI) should fail" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createRequest(attribute = "$CONSENT=\"$incorrectUri\""))).let {
                 shouldThrow<SAMLComplianceException> {
                     RequestVerifierTest(it).verify()
@@ -140,6 +140,6 @@ class RequestVerifierSpec : StringSpec() {
            """.trimMargin()
     }
 
-    private class RequestVerifierTest(samlRequestDom: NodeWrapper) :
+    private class RequestVerifierTest(samlRequestDom: NodeDecorator) :
             RequestVerifier(samlRequestDom, HTTP_POST)
 }

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/ResponseVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/ResponseVerifierSpec.kt
@@ -32,7 +32,7 @@ import org.codice.compliance.SAMLGeneral_e
 import org.codice.compliance.TEST_SP_METADATA_PROPERTY
 import org.codice.compliance.utils.CONSENT
 import org.codice.compliance.utils.DESTINATION
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.PARTIAL_LOGOUT
 import org.codice.compliance.utils.REQUESTER
 import org.codice.compliance.utils.SUCCESS
@@ -75,17 +75,17 @@ class ResponseVerifierSpec : StringSpec() {
                 Resources.getResource("test-sp-metadata.xml").path)
 
         "response with correct fields should pass" {
-            NodeWrapper(Common.buildDom(createResponse())).let {
+            NodeDecorator(Common.buildDom(createResponse())).let {
                 ResponseVerifierTest(request, it, HTTP_POST).verify()
             }
         }
 
         "response with non-unique ID should fail" {
-            NodeWrapper(Common.buildDom(createResponse(id = "not-unique-id"))).let {
+            NodeDecorator(Common.buildDom(createResponse(id = "not-unique-id"))).let {
                 ResponseVerifierTest(request, it, HTTP_POST).verify()
             }
 
-            NodeWrapper(Common.buildDom(createResponse(id = "not-unique-id"))).let {
+            NodeDecorator(Common.buildDom(createResponse(id = "not-unique-id"))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
                 }.message?.apply {
@@ -96,7 +96,7 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with incorrect InResponseTo should fail" {
-            NodeWrapper(Common.buildDom(createResponse(inResponseTo = "incorrect"))).let {
+            NodeDecorator(Common.buildDom(createResponse(inResponseTo = "incorrect"))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
                 }.message?.shouldContain(SAMLCore_3_2_2_b.message)
@@ -104,7 +104,7 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with blank version should fail" {
-            NodeWrapper(Common.buildDom(createResponse(version = " "))).let {
+            NodeDecorator(Common.buildDom(createResponse(version = " "))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
                 }.message?.shouldContain(SAMLCore_1_3_1_a.message)
@@ -112,7 +112,7 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with non-utc instant issuer should fail" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createResponse(instant = "2018-05-01T06:15:30-07:00"))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
@@ -124,14 +124,14 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with correct destination should pass" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createResponse(attribute = "$DESTINATION=\"$correctUri\""))).let {
                 ResponseVerifierTest(request, it, HTTP_POST).verify()
             }
         }
 
         "response with incorrect destination should fail" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createResponse(attribute = "$DESTINATION=\"$incorrectUri\""))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
@@ -140,14 +140,14 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with correct consent should pass" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createResponse(attribute = "$CONSENT=\"$correctUri\""))).let {
                 ResponseVerifierTest(request, it, HTTP_POST).verify()
             }
         }
 
         "response with non-uri consent should fail" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createResponse(attribute = "$CONSENT=\"$incorrectUri\""))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
@@ -156,7 +156,7 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with a top level status code that isn't success should fail" {
-            NodeWrapper(Common.buildDom(createResponse(statusCode = REQUESTER))).let {
+            NodeDecorator(Common.buildDom(createResponse(statusCode = REQUESTER))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
                 }.message?.shouldContain(SAMLGeneral_e.message)
@@ -164,7 +164,7 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with a second-level status code as top-level should fail" {
-            NodeWrapper(Common.buildDom(createResponse(statusCode = PARTIAL_LOGOUT))).let {
+            NodeDecorator(Common.buildDom(createResponse(statusCode = PARTIAL_LOGOUT))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
                 }.message?.shouldContain(SAMLCore_3_2_2_2_a.message)
@@ -172,7 +172,7 @@ class ResponseVerifierSpec : StringSpec() {
         }
 
         "response with a blank status message should fail" {
-            NodeWrapper(Common.buildDom(createResponse(statusMessage = " "))).let {
+            NodeDecorator(Common.buildDom(createResponse(statusMessage = " "))).let {
                 shouldThrow<SAMLComplianceException> {
                     ResponseVerifierTest(request, it, HTTP_POST).verify()
                 }.message?.shouldContain(SAMLCore_1_3_1_a.message)
@@ -207,7 +207,7 @@ class ResponseVerifierSpec : StringSpec() {
     }
 
     private class ResponseVerifierTest(samlRequest: RequestAbstractType,
-                                       samlResponseDom: NodeWrapper,
+                                       samlResponseDom: NodeDecorator,
                                        binding: SamlProtocol.Binding)
         : ResponseVerifier(samlRequest, samlResponseDom, binding)
 }

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/requests/CoreLogoutRequestProtocolVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/requests/CoreLogoutRequestProtocolVerifierSpec.kt
@@ -22,7 +22,7 @@ import org.codice.compliance.SAMLCore_1_3_2_a
 import org.codice.compliance.SAMLCore_1_3_3_a
 import org.codice.compliance.SAMLCore_3_7_1_a
 import org.codice.compliance.SAMLCore_3_7_3_2_e
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.verification.core.requests.CoreLogoutRequestProtocolVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
@@ -35,16 +35,17 @@ class CoreLogoutRequestProtocolVerifierSpec : StringSpec() {
 
     init {
         "logout request with correct reason should pass" {
-            NodeWrapper(Common.buildDom(
-                    createLogoutRequest("Reason=\"http://correct.reason/uri\"",
+            NodeDecorator(Common.buildDom(
+                    createLogoutRequest("""Reason="http://correct.reason/uri"""",
                             correctNotOnOrAfter))).let {
                 CoreLogoutRequestProtocolVerifier(it, HTTP_REDIRECT).verify()
             }
         }
 
         "logout request with incorrect reason (relative URI) should fail with SAMLCore_3_7_1_a" {
-            NodeWrapper(Common.buildDom(createLogoutRequest("Reason=\"/incorrect/reason/uri\"",
-                    correctNotOnOrAfter))).let {
+            NodeDecorator(Common.buildDom(
+                    createLogoutRequest("""Reason="/incorrect/reason/uri"""",
+                            correctNotOnOrAfter))).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreLogoutRequestProtocolVerifier(it, HTTP_POST).verify()
                 }.message
@@ -55,14 +56,14 @@ class CoreLogoutRequestProtocolVerifierSpec : StringSpec() {
         }
 
         "logout request with correct NotOnOrAfter should pass" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createLogoutRequest("", "2018-05-01T13:15:30Z"))).let {
                 CoreLogoutRequestProtocolVerifier(it, HTTP_REDIRECT).verify()
             }
         }
 
         "logout request with incorrect NotOnOrAfter (non-UTC) should fail with SAMLCore_3_7_1_a" {
-            NodeWrapper(Common.buildDom(
+            NodeDecorator(Common.buildDom(
                     createLogoutRequest("", "2018-05-01T06:15:30-07:00"))).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreLogoutRequestProtocolVerifier(it, HTTP_POST).verify()
@@ -71,7 +72,7 @@ class CoreLogoutRequestProtocolVerifierSpec : StringSpec() {
         }
 
         "logout request with no NotOnOrAfter should fail with SAMLCore_3_7_3_2_e" {
-            NodeWrapper(Common.buildDom(createLogoutRequest("", null))).let {
+            NodeDecorator(Common.buildDom(createLogoutRequest("", null))).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreLogoutRequestProtocolVerifier(it, HTTP_POST).verify()
                 }.message?.shouldContain(SAMLCore_3_7_3_2_e.message)

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/response/CoreLogoutResponseProtocolVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/response/CoreLogoutResponseProtocolVerifierSpec.kt
@@ -20,7 +20,7 @@ import org.codice.compliance.Common
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_7_3_2_b
 import org.codice.compliance.SAMLCore_3_7_3_2_d
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.PERSISTENT_ID
 import org.codice.compliance.utils.RESPONDER
 import org.codice.compliance.utils.SUCCESS
@@ -58,13 +58,13 @@ class CoreLogoutResponseProtocolVerifierSpec : StringSpec() {
 
     init {
         "logout response with correct second-level status code should pass" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(SUCCESS))).let {
+            NodeDecorator(Common.buildDom(createLogoutResponse(SUCCESS))).let {
                 CoreLogoutResponseProtocolVerifier(logoutRequest, it, HTTP_POST, SUCCESS).verify()
             }
         }
 
         "logout response with incorrect second-level status code should fail" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(RESPONDER))).let {
+            NodeDecorator(Common.buildDom(createLogoutResponse(RESPONDER))).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreLogoutResponseProtocolVerifier(logoutRequest, it, HTTP_POST, SUCCESS)
                             .verify()
@@ -76,7 +76,7 @@ class CoreLogoutResponseProtocolVerifierSpec : StringSpec() {
         }
 
         "logout response with no second-level status code when expected should fail" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(null))).let {
+            NodeDecorator(Common.buildDom(createLogoutResponse(null))).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreLogoutResponseProtocolVerifier(logoutRequest, it, HTTP_POST, SUCCESS)
                             .verify()
@@ -88,7 +88,7 @@ class CoreLogoutResponseProtocolVerifierSpec : StringSpec() {
         }
 
         "logout response with a second-level status code when not expecting one should pass" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(SUCCESS))).let {
+            NodeDecorator(Common.buildDom(createLogoutResponse(SUCCESS))).let {
                 CoreLogoutResponseProtocolVerifier(logoutRequest, it, HTTP_POST).verify()
             }
         }

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/profile/SingleLogoutProfileVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/profile/SingleLogoutProfileVerifierSpec.kt
@@ -27,7 +27,7 @@ import org.codice.compliance.SAMLProfiles_4_4_4_1_b
 import org.codice.compliance.SAMLProfiles_4_4_4_1_c
 import org.codice.compliance.SAMLProfiles_4_4_4_2_a
 import org.codice.compliance.SAMLProfiles_4_4_4_2_b
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.verification.profile.SingleLogoutProfileVerifier
 import java.time.Instant
 
@@ -64,14 +64,14 @@ class SingleLogoutProfileVerifierSpec : StringSpec() {
                 Resources.getResource("implementation").path)
 
         "logout request with correct issuer should pass" {
-            NodeWrapper(Common.buildDom(createLogoutRequest(correctIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutRequest(correctIdpIssuer)),
                     isSigned = true).let {
                 SingleLogoutProfileVerifier(it).verifyLogoutRequest(ssoResponse)
             }
         }
 
         "verify logout request with logout response should fail" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(incorrectIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutResponse(incorrectIdpIssuer)),
                     isSigned = true).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleLogoutProfileVerifier(it).verifyLogoutRequest(ssoResponse)
@@ -80,7 +80,7 @@ class SingleLogoutProfileVerifierSpec : StringSpec() {
         }
 
         "unsigned logout request should fail" {
-            NodeWrapper(Common.buildDom(createLogoutRequest(correctIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutRequest(correctIdpIssuer)),
                     isSigned = false).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleLogoutProfileVerifier(it).verifyLogoutRequest(ssoResponse)
@@ -89,7 +89,7 @@ class SingleLogoutProfileVerifierSpec : StringSpec() {
         }
 
         "logout request with incorrect issuer should fail" {
-            NodeWrapper(Common.buildDom(createLogoutRequest(incorrectIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutRequest(incorrectIdpIssuer)),
                     isSigned = true).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleLogoutProfileVerifier(it).verifyLogoutRequest(ssoResponse)
@@ -98,7 +98,7 @@ class SingleLogoutProfileVerifierSpec : StringSpec() {
         }
 
         "logout request with non-matching NameID should fail" {
-            NodeWrapper(
+            NodeDecorator(
                     Common.buildDom(createLogoutRequest(correctIdpIssuer, incorrectNameIDValue)),
                     isSigned = true).let {
                 shouldThrow<SAMLComplianceException> {
@@ -108,14 +108,14 @@ class SingleLogoutProfileVerifierSpec : StringSpec() {
         }
 
         "logout response with correct issuer should pass" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(correctIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutResponse(correctIdpIssuer)),
                     isSigned = true).let {
                 SingleLogoutProfileVerifier(it).verifyLogoutResponse()
             }
         }
 
         "verify logout response with logout request should fail" {
-            NodeWrapper(Common.buildDom(createLogoutRequest(incorrectIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutRequest(incorrectIdpIssuer)),
                     isSigned = true).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleLogoutProfileVerifier(it).verifyLogoutResponse()
@@ -124,7 +124,7 @@ class SingleLogoutProfileVerifierSpec : StringSpec() {
         }
 
         "unsigned logout response should fail" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(correctIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutResponse(correctIdpIssuer)),
                     isSigned = false).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleLogoutProfileVerifier(it).verifyLogoutResponse()
@@ -133,7 +133,7 @@ class SingleLogoutProfileVerifierSpec : StringSpec() {
         }
 
         "logout response with incorrect issuer should fail" {
-            NodeWrapper(Common.buildDom(createLogoutResponse(incorrectIdpIssuer)),
+            NodeDecorator(Common.buildDom(createLogoutResponse(incorrectIdpIssuer)),
                     isSigned = true).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleLogoutProfileVerifier(it).verifyLogoutResponse()

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/profile/SingleSignOnProfileVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/profile/SingleSignOnProfileVerifierSpec.kt
@@ -25,7 +25,7 @@ import org.codice.compliance.SAMLProfiles_4_1_4_2_b
 import org.codice.compliance.SAMLProfiles_4_1_4_2_c
 import org.codice.compliance.TEST_SP_METADATA_PROPERTY
 import org.codice.compliance.utils.BEARER
-import org.codice.compliance.utils.NodeWrapper
+import org.codice.compliance.utils.NodeDecorator
 import org.codice.compliance.utils.SUCCESS
 import org.codice.compliance.utils.TestCommon.Companion.REQUEST_ID
 import org.codice.compliance.verification.core.CoreVerifier
@@ -147,13 +147,13 @@ class SingleSignOnProfileVerifierSpec : StringSpec() {
                 Resources.getResource("test-sp-metadata.xml").path)
 
         "unsigned response with no issuer on response element should pass" {
-            NodeWrapper(Common.buildDom(createResponse(issuer = ""))).let {
+            NodeDecorator(Common.buildDom(createResponse(issuer = ""))).let {
                 SingleSignOnProfileVerifier(it).verify()
             }
         }
 
         "signed response with no issuer on response element should fail" {
-            NodeWrapper(Common.buildDom(createResponse(issuer = "")), isSigned = true).let {
+            NodeDecorator(Common.buildDom(createResponse(issuer = "")), isSigned = true).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleSignOnProfileVerifier(it).verify()
                 }.message?.shouldContain(SAMLProfiles_4_1_4_2_a.message)
@@ -161,7 +161,7 @@ class SingleSignOnProfileVerifierSpec : StringSpec() {
         }
 
         "response with incorrect assertion issuer value should fail" {
-            NodeWrapper(Common.buildDom(createResponse(assertionIssuer = "wrong"))).let {
+            NodeDecorator(Common.buildDom(createResponse(assertionIssuer = "wrong"))).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleSignOnProfileVerifier(it).verify()
                 }.message?.shouldContain(SAMLProfiles_4_1_4_2_c.message)
@@ -170,7 +170,7 @@ class SingleSignOnProfileVerifierSpec : StringSpec() {
 
         "response with no assertion should fail" {
             val noAssertionResponse = "<s:Response $responseParams/>"
-            NodeWrapper(Common.buildDom(noAssertionResponse)).let {
+            NodeDecorator(Common.buildDom(noAssertionResponse)).let {
                 shouldThrow<SAMLComplianceException> {
                     SingleSignOnProfileVerifier(it).verify()
                 }.message?.shouldContain(SAMLProfiles_4_1_4_2_b.message)
@@ -178,14 +178,14 @@ class SingleSignOnProfileVerifierSpec : StringSpec() {
         }
 
         "unsigned response with encrypted assertion and correct issuer should pass" {
-            NodeWrapper(Common.buildDom(correctEncryptedResponse)).let {
+            NodeDecorator(Common.buildDom(correctEncryptedResponse)).let {
                 CoreVerifierTest(it).verify()
                 SingleSignOnProfileVerifier(it).verify()
             }
         }
 
         "unsigned response with encrypted assertion and incorrect issuer should fail" {
-            NodeWrapper(Common.buildDom(incorrectEncryptedResponse)).let {
+            NodeDecorator(Common.buildDom(incorrectEncryptedResponse)).let {
                 shouldThrow<SAMLComplianceException> {
                     CoreVerifierTest(it).verify()
                     SingleSignOnProfileVerifier(it).verify()
@@ -231,4 +231,4 @@ class SingleSignOnProfileVerifierSpec : StringSpec() {
     }
 }
 
-class CoreVerifierTest(samlNode: NodeWrapper) : CoreVerifier(samlNode)
+class CoreVerifierTest(samlNode: NodeDecorator) : CoreVerifier(samlNode)

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/PostSLOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/PostSLOTest.kt
@@ -69,7 +69,7 @@ class PostSLOTest : StringSpec() {
             SingleLogoutProfileVerifier(samlLogoutRequestDom).verifyLogoutRequest(ssoResponseDom)
 
             val secondSPLogoutResponse =
-                    createDefaultLogoutResponse(samlLogoutRequestDom.node, true)
+                    createDefaultLogoutResponse(samlLogoutRequestDom, true)
             val encodedSecondSPLogoutResponse =
                 signAndEncodePostRequestToString(secondSPLogoutResponse, logoutRequestRelayState)
             val logoutResponse = sendPostLogoutMessage(encodedSecondSPLogoutResponse)
@@ -114,7 +114,7 @@ class PostSLOTest : StringSpec() {
             SingleLogoutProfileVerifier(samlLogoutRequestDom).verifyLogoutRequest(ssoResponseDom)
 
             val secondSPLogoutResponse =
-                    createDefaultLogoutResponse(samlLogoutRequestDom.node, true)
+                    createDefaultLogoutResponse(samlLogoutRequestDom, true)
             val encodedSecondSPLogoutResponse =
                 signAndEncodePostRequestToString(secondSPLogoutResponse, logoutRequestRelayState)
             val logoutResponse = sendPostLogoutMessage(encodedSecondSPLogoutResponse)
@@ -146,7 +146,7 @@ class PostSLOTest : StringSpec() {
 
             // Send a response with an error saml status code
             val secondSPLogoutResponse =
-                    createDefaultLogoutResponse(samlLogoutRequestDom.node, false)
+                    createDefaultLogoutResponse(samlLogoutRequestDom, false)
             val encodedSecondSPLogoutResponse =
                 signAndEncodePostRequestToString(secondSPLogoutResponse, logoutRequestRelayState)
             val logoutResponse = sendPostLogoutMessage(encodedSecondSPLogoutResponse)

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
@@ -80,7 +80,7 @@ class RedirectSLOTest : StringSpec() {
             SingleLogoutProfileVerifier(samlLogoutRequestDom).verifyLogoutRequest(ssoResponseDom)
 
             val secondSPLogoutResponse =
-                    createDefaultLogoutResponse(samlLogoutRequestDom.node, true)
+                    createDefaultLogoutResponse(samlLogoutRequestDom, true)
             val encodedSecondSPLogoutResponse = encodeRedirectRequest(secondSPLogoutResponse)
             val secondSPResponseQueryParams = SimpleSign().signUriString(
                 SAML_RESPONSE,
@@ -134,7 +134,7 @@ class RedirectSLOTest : StringSpec() {
             SingleLogoutProfileVerifier(samlLogoutRequestDom).verifyLogoutRequest(ssoResponseDom)
 
             val secondSPLogoutResponse =
-                    createDefaultLogoutResponse(samlLogoutRequestDom.node, true)
+                    createDefaultLogoutResponse(samlLogoutRequestDom, true)
             val encodedSecondSPLogoutResponse = encodeRedirectRequest(secondSPLogoutResponse)
             val secondSPResponseQueryParams = SimpleSign().signUriString(
                 SAML_RESPONSE,
@@ -172,7 +172,7 @@ class RedirectSLOTest : StringSpec() {
 
             // Send a response with an error saml status code
             val secondSPLogoutResponse =
-                    createDefaultLogoutResponse(samlLogoutRequestDom.node, false)
+                    createDefaultLogoutResponse(samlLogoutRequestDom, false)
             val encodedSecondSPLogoutResponse = encodeRedirectRequest(secondSPLogoutResponse)
             val secondSPResponseQueryParams = SimpleSign().signUriString(
                 SAML_RESPONSE,

--- a/library/src/main/kotlin/org/codice/compliance/DecoratedNode.kt
+++ b/library/src/main/kotlin/org/codice/compliance/DecoratedNode.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.compliance
+
+import org.w3c.dom.Node
+
+interface DecoratedNode {
+    fun getNode(): Node
+}

--- a/library/src/main/kotlin/org/codice/compliance/W3CNodeExtensions.kt
+++ b/library/src/main/kotlin/org/codice/compliance/W3CNodeExtensions.kt
@@ -101,9 +101,14 @@ fun Node.attributeList(): List<Node> {
 fun Node.prettyPrintXml(): String {
     // Remove whitespaces outside tags
     normalize()
+    val thisNode = if (this is DecoratedNode)
+        this.getNode()
+    else
+        this
+
     val xPath = XPathFactory.newInstance().newXPath()
     val nodeList = xPath.evaluate("//text()[normalize-space()='']",
-            this,
+            thisNode,
             XPathConstants.NODESET) as NodeList
     for (i in 0 until nodeList.length) {
         val node = nodeList.item(i)
@@ -112,7 +117,7 @@ fun Node.prettyPrintXml(): String {
 
     val transformer = createTransformer()
     val output = StringWriter()
-    transformer.transform(DOMSource(this), StreamResult(output))
+    transformer.transform(DOMSource(thisNode), StreamResult(output))
     return output.toString()
 }
 


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
- Renames `NodeWrapper` to `NodeDecorator`
- Changes `NodeDecorator` to use the `by` keyword to delegate to the passed in `Node` object
- Removes all references to the internal `Node` object (except for the `prettyPrintXml` method)
- Introduces `DecoratedNode` interface so that the `prettyPrintXml` method works correctly (thank you @coyotesqrl)

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [X] Unit Tests Added/Modified