### PR TITLE
MAINT - Added a DDF profile flag to allow the profile to be run against non-DDF IDPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,13 @@ The `samlconf` script may take the following parameters:
            are optional and if they are not provided, the default values will use DDF's parameters.
     
     OPTIONS
-           -d
+           -debug
                 Boolean for whether or not to enable debug mode which enables more logging.
                 The default value is false.
+
+           -ddf
+                Run the DDF profile. If provided runs the optional SAML V2.0 Standard
+                Specification rules required by DDF.
 
            -i path
                 The path to the directory containing the implementation's plugin and metadata.

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SubjectComparisonVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SubjectComparisonVerifier.kt
@@ -14,7 +14,6 @@
 package org.codice.compliance.verification.core
 
 import com.google.common.collect.Sets
-import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_3_4_b
 import org.codice.compliance.SAMLCore_3_3_4_c
@@ -109,8 +108,7 @@ class SubjectComparisonVerifier(private val samlResponseDom: Node) {
                 "Could not find the logout request's identifier.")
 
         // Not handled correctly by DDF, so temporarily disabling this. See DDF-3951.
-        if (!runningAgainstDDF())
-            verifyIdAttributesMatch(assertionId, logoutRequestId, SAMLProfiles_4_4_4_1_c)
+        // verifyIdAttributesMatch(assertionId, logoutRequestId, SAMLProfiles_4_4_4_1_c)
         verifyIdContentsMatch(assertionId, logoutRequestId, SAMLProfiles_4_4_4_1_c)
     }
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/responses/CoreAuthnRequestProtocolVerifier.kt
@@ -14,7 +14,6 @@
 package org.codice.compliance.verification.core.responses
 
 import io.restassured.response.Response
-import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_3_4_1_4_a
 import org.codice.compliance.SAMLCore_3_4_1_4_b
@@ -54,8 +53,7 @@ class CoreAuthnRequestProtocolVerifier(private val authnRequest: AuthnRequest,
         verifyAuthnRequestProtocolResponse()
         verifySubjects()
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy, uncomment this line
-        if (!runningAgainstDDF())
-            nameIdPolicyVerifier?.verify()
+        // nameIdPolicyVerifier?.verify()
     }
 
     fun verifyAssertionConsumerService(httpResponse: Response) {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -18,7 +18,6 @@ import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.wss4j.common.saml.builder.SAML2Constants
-import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.saml.plugin.IdpSSOResponder
 import org.codice.compliance.utils.ENCRYPTED_ID
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
@@ -110,7 +109,7 @@ class PostSSOTest : StringSpec() {
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
         "POST AuthnRequest With Email NameIDPolicy Format Test".config(
-                enabled = !runningAgainstDDF()) {
+                enabled = false) {
             val authnRequest = createDefaultAuthnRequest(HTTP_POST).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = SAML2Constants.NAMEID_FORMAT_EMAIL_ADDRESS
@@ -140,7 +139,7 @@ class PostSSOTest : StringSpec() {
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
         "POST AuthnRequest With Encrypted NameIDPolicy Format Test".config(
-                enabled = !runningAgainstDDF()) {
+                enabled = false) {
             val authnRequest = createDefaultAuthnRequest(HTTP_POST).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = ENCRYPTED_ID

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -19,7 +19,6 @@ import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
 import org.apache.wss4j.common.saml.builder.SAML2Constants
-import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.saml.plugin.IdpSSOResponder
 import org.codice.compliance.utils.ENCRYPTED_ID
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
@@ -156,7 +155,7 @@ class RedirectSSOTest : StringSpec() {
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
         "Redirect AuthnRequest With Email NameID Format Test".config(
-                enabled = !runningAgainstDDF()) {
+                enabled = false) {
             val authnRequest = createDefaultAuthnRequest(HTTP_REDIRECT).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = SAML2Constants.NAMEID_FORMAT_EMAIL_ADDRESS
@@ -192,7 +191,7 @@ class RedirectSSOTest : StringSpec() {
         // TODO When DDF is fixed to return NameID format based on NameIDPolicy,
         // re-enable this test
         "Redirect AuthnRequest With Encrypted NameID Format Test".config(
-                enabled = !runningAgainstDDF()) {
+                enabled = false) {
             val authnRequest = createDefaultAuthnRequest(HTTP_REDIRECT).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = ENCRYPTED_ID

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/PostSSOErrorTest.kt
@@ -17,7 +17,6 @@ import io.kotlintest.TestCaseConfig
 import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
-import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
 import org.codice.compliance.SAMLBindings_3_5_3_a
 import org.codice.compliance.SAMLComplianceException
@@ -90,7 +89,7 @@ class PostSSOErrorTest : StringSpec() {
 
         // TODO - DDF responds with a successful response. Re-enable test when DDF handles this
         "Profiles 4.1.4.1: POST AuthnRequest With Subject Containing an Invalid Name ID Test"
-            .config(enabled = !runningAgainstDDF()) {
+            .config(enabled = false) {
                 try {
                     val authnRequest =
                         createDefaultAuthnRequest(HTTP_POST).apply {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/error/RedirectSSOErrorTest.kt
@@ -18,7 +18,6 @@ import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
-import org.codice.compliance.Common.Companion.runningAgainstDDF
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
 import org.codice.compliance.SAMLBindings_3_4_3_a
 import org.codice.compliance.SAMLComplianceException
@@ -123,7 +122,7 @@ class RedirectSSOErrorTest : StringSpec() {
 
         // TODO - DDF responds with a successful response. Re-enable test when DDF handles this
         "Profiles 4.1.4.1: Redirect AuthnRequest With Subject Containing an Invalid Name ID Test"
-                .config(enabled = !runningAgainstDDF()) {
+                .config(enabled = false) {
                 try {
                     val authnRequest =
                         createDefaultAuthnRequest(HTTP_REDIRECT).apply {

--- a/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
+++ b/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
@@ -18,6 +18,7 @@ import de.jupf.staticlog.core.LogLevel
 import org.codice.compliance.DEFAULT_IMPLEMENTATION_PATH
 import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.LENIENT_ERROR_VERIFICATION
+import org.codice.compliance.RUN_DDF_PROFILE
 import org.codice.compliance.TEST_SP_METADATA_PROPERTY
 import org.codice.compliance.USER_LOGIN
 import org.codice.compliance.web.slo.PostSLOTest
@@ -56,44 +57,44 @@ fun main(args: Array<String>) {
     val samlDist = System.getProperty("app.home")
     requireNotNull(samlDist) { "app.home System property must be set" }
 
-    val parser = Parser()
-    parser.setName("SAML CTK")
-    parser.setApplicationDescription("SAML Conformance Test Kit")
-
-    parser.option("i",
-            description = "Path to the implementation to be tested")
-
-    parser.option("u",
-            description = "User used to login in the format username:password.")
-
-    parser.flag("d",
-            description = "Turn on debug logs.")
-
-    parser.flag("l",
-            description = """When an error occurs, the SAML V2.0 Standard Specification requires an
-                IdP to respond with a 200 HTTP status code and a valid SAML response containing an
-                error <StatusCode>. If the -l flag is given, this test kit will allow HTTP error
-                status codes as a valid error response.""")
-
+    val parser = createParser()
     val arguments = parser.parse(args)
 
     val implementationPath = arguments.option("i")
             ?: "$samlDist/$DEFAULT_IMPLEMENTATION_PATH"
-
     val userLogin = arguments.option("i") ?: "admin:admin"
 
     System.setProperty(IMPLEMENTATION_PATH, implementationPath)
     System.setProperty(USER_LOGIN, userLogin)
     System.setProperty(TEST_SP_METADATA_PROPERTY, "$samlDist/conf/samlconf-sp-metadata.xml")
     System.setProperty(LENIENT_ERROR_VERIFICATION, arguments.flag("l").toString())
+    System.setProperty(RUN_DDF_PROFILE, arguments.flag("ddf").toString())
 
-    if (arguments.flag("d")) {
+    if (arguments.flag("debug")) {
         Log.logLevel = LogLevel.DEBUG
     } else {
         Log.logLevel = LogLevel.INFO
     }
 
     launchTests()
+}
+
+private fun createParser(): Parser {
+    return Parser().apply {
+        setName("SAML CTK")
+        setApplicationDescription("SAML Conformance Test Kit")
+
+        option("i", description = "Path to the implementation to be tested")
+        option("u", description = "User used to login in the format username:password.")
+
+        flag("debug", description = "Turn on debug logs.")
+        flag("ddf", description = """Run the DDF profile. If provided runs the optional
+            SAML V2.0 StandardSpecification rules required by DDF.""")
+        flag("l", description = """When an error occurs, the SAML V2.0 Standard
+            Specification requires an IdP to respond with a 200 HTTP status code and a valid SAML
+            response containing an error <StatusCode>. If the -l flag is given, this test kit will
+            allow HTTP error status codes as a valid error response.""")
+    }
 }
 
 @Suppress("SpreadOperator")

--- a/deployment/docker/wait.sh
+++ b/deployment/docker/wait.sh
@@ -34,4 +34,4 @@ done
 curl -LsSk "https://${_sut_host}:${_sut_port}/${_sut_idp_metadata}" -o "${_sut_ddf_implementation}/ddf-idp-metadata.xml"
 
 >&2 echo "DDF is up - executing command"
-exec ./samlconf/bin/samlconf -i ${_sut_ddf_implementation} -l
+exec ./samlconf/bin/samlconf -i ${_sut_ddf_implementation} -l -ddf

--- a/library/src/main/kotlin/org/codice/compliance/Common.kt
+++ b/library/src/main/kotlin/org/codice/compliance/Common.kt
@@ -36,6 +36,7 @@ const val DEFAULT_IMPLEMENTATION_PATH = "implementations/ddf"
 const val USER_LOGIN = "user.login"
 const val TEST_SP_METADATA_PROPERTY = "test.sp.metadata"
 const val LENIENT_ERROR_VERIFICATION = "lenient.error.verification"
+const val RUN_DDF_PROFILE = "run.ddf.profile"
 
 class Common {
     companion object {
@@ -127,8 +128,7 @@ class Common {
             }
         }
 
-        fun runningAgainstDDF() = System.getProperty(IMPLEMENTATION_PATH).contains(
-                DEFAULT_IMPLEMENTATION_PATH)
+        fun runningDDFProfile() = (System.getProperty(RUN_DDF_PROFILE) == "true")
     }
 }
 


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Added a DDF profile flag to allow the profile to be run against non-DDF IDPs.

The point of the DDF profile is for it to be run against non-DDF IdP to see if they can interoperate successfully. 
> Change for dev - add the -ddf flag when running the tests

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified