### PR TITLE
SLO - Added tests for using a DSA SHA256 signature for DDF profile

### DIFF
--- a/ctk/common/src/main/java/org/codice/compliance/utils/sign/SimpleSign.java
+++ b/ctk/common/src/main/java/org/codice/compliance/utils/sign/SimpleSign.java
@@ -74,18 +74,16 @@ public class SimpleSign {
 
   // DDF Difference: Uses SHA1 for the hashing mechanism when signing by default instead of SHA256.
   public SimpleSign() throws IOException {
-    crypto = new SystemCrypto(getCurrentSPHostname());
-    rsaAlgoUri = WSS4JConstants.RSA;
-    rsaAlgoJce = JCEMapper.translateURItoJCEID(rsaAlgoUri);
-    dsaAlgoUri = WSS4JConstants.DSA;
-    dsaAlgoJce = JCEMapper.translateURItoJCEID(dsaAlgoUri);
+    this(WSS4JConstants.DSA);
   }
 
   // DDF Difference: The signing algorithm is not configurable in DDF.
-  public SimpleSign(String rsaAlgoUri, String dsaAlgoUri) throws IOException {
+  public SimpleSign(String dsaAlgoUri) throws IOException {
     crypto = new SystemCrypto(getCurrentSPHostname());
-    this.rsaAlgoUri = rsaAlgoUri;
+
+    this.rsaAlgoUri = WSS4JConstants.RSA;
     rsaAlgoJce = JCEMapper.translateURItoJCEID(rsaAlgoUri);
+
     this.dsaAlgoUri = dsaAlgoUri;
     dsaAlgoJce = JCEMapper.translateURItoJCEID(dsaAlgoUri);
   }

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/PostSLOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/PostSLOTest.kt
@@ -39,6 +39,7 @@ import org.codice.compliance.verification.core.responses.CoreLogoutResponseProto
 import org.codice.compliance.verification.profile.SingleLogoutProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.codice.security.sign.Encoder
+import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA256
 
 class PostSLOTest : StringSpec() {
     override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SLO))
@@ -173,7 +174,7 @@ class PostSLOTest : StringSpec() {
 
             val logoutRequest = createDefaultLogoutRequest(HTTP_POST)
 
-            SimpleSign().signSamlObject(logoutRequest)
+            SimpleSign(ALGO_ID_SIGNATURE_DSA_SHA256).signSamlObject(logoutRequest)
             val requestString = TestCommon.samlObjectToString(logoutRequest)
             requestString.debugPrettyPrintXml(SSOConstants.SAML_REQUEST)
 

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
@@ -38,7 +38,6 @@ import org.codice.compliance.verification.core.responses.CoreLogoutResponseProto
 import org.codice.compliance.verification.profile.SingleLogoutProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
 import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA256
-import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256
 
 class RedirectSLOTest : StringSpec() {
     override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SLO))
@@ -199,8 +198,7 @@ class RedirectSLOTest : StringSpec() {
 
             val logoutRequest = createDefaultLogoutRequest(HTTP_REDIRECT)
             val encodedRequest = encodeRedirectRequest(logoutRequest)
-            val queryParams = SimpleSign(ALGO_ID_SIGNATURE_RSA_SHA256,
-                    ALGO_ID_SIGNATURE_DSA_SHA256).signUriString(
+            val queryParams = SimpleSign(ALGO_ID_SIGNATURE_DSA_SHA256).signUriString(
                     SAML_REQUEST,
                     encodedRequest,
                     null)

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/slo/RedirectSLOTest.kt
@@ -19,6 +19,7 @@ import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_REQUEST
 import org.apache.cxf.rs.security.saml.sso.SSOConstants.SAML_RESPONSE
+import org.codice.compliance.Common.Companion.runningDDFProfile
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.PARTIAL_LOGOUT
 import org.codice.compliance.utils.SLOCommon.Companion.createDefaultLogoutRequest
@@ -36,6 +37,8 @@ import org.codice.compliance.verification.core.requests.CoreLogoutRequestProtoco
 import org.codice.compliance.verification.core.responses.CoreLogoutResponseProtocolVerifier
 import org.codice.compliance.verification.profile.SingleLogoutProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
+import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA256
+import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256
 
 class RedirectSLOTest : StringSpec() {
     override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SLO))
@@ -186,6 +189,26 @@ class RedirectSLOTest : StringSpec() {
             }.decodeAndVerify()
             CoreLogoutResponseProtocolVerifier(logoutRequest, samlResponseDom,
                 logoutResponse.determineBinding(), PARTIAL_LOGOUT).verify()
+            SingleLogoutProfileVerifier(samlResponseDom).verifyLogoutResponse()
+        }
+
+        "DDF-Specific: Redirect LogoutRequest With SHA256 Signature Test - Single SP".config(
+                enabled = runningDDFProfile()) {
+            useDSAServiceProvider()
+            login(HTTP_REDIRECT)
+
+            val logoutRequest = createDefaultLogoutRequest(HTTP_REDIRECT)
+            val encodedRequest = encodeRedirectRequest(logoutRequest)
+            val queryParams = SimpleSign(ALGO_ID_SIGNATURE_RSA_SHA256,
+                    ALGO_ID_SIGNATURE_DSA_SHA256).signUriString(
+                    SAML_REQUEST,
+                    encodedRequest,
+                    null)
+            val response = sendRedirectLogoutMessage(queryParams)
+
+            val samlResponseDom = response.getBindingVerifier().decodeAndVerify()
+            CoreLogoutResponseProtocolVerifier(logoutRequest, samlResponseDom,
+                    response.determineBinding()).verify()
             SingleLogoutProfileVerifier(samlResponseDom).verifyLogoutResponse()
         }
     }

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -17,24 +17,32 @@ import io.kotlintest.TestCaseConfig
 import io.kotlintest.provided.SSO
 import io.kotlintest.specs.StringSpec
 import io.restassured.RestAssured
+import org.apache.cxf.rs.security.saml.sso.SSOConstants
 import org.apache.wss4j.common.saml.builder.SAML2Constants
+import org.codice.compliance.debugPrettyPrintXml
 import org.codice.compliance.Common.Companion.runningDDFProfile
 import org.codice.compliance.saml.plugin.IdpSSOResponder
 import org.codice.compliance.utils.EXAMPLE_RELAY_STATE
 import org.codice.compliance.utils.SSOCommon.Companion.createDefaultAuthnRequest
 import org.codice.compliance.utils.SSOCommon.Companion.sendPostAuthnRequest
+import org.codice.compliance.utils.TestCommon
 import org.codice.compliance.utils.TestCommon.Companion.currentSPIssuer
 import org.codice.compliance.utils.TestCommon.Companion.getImplementation
 import org.codice.compliance.utils.TestCommon.Companion.signAndEncodePostRequestToString
 import org.codice.compliance.utils.ddfAuthnContextList
+import org.codice.compliance.utils.TestCommon.Companion.useDSAServiceProvider
 import org.codice.compliance.utils.getBindingVerifier
+import org.codice.compliance.utils.sign.SimpleSign
 import org.codice.compliance.verification.binding.BindingVerifier
 import org.codice.compliance.verification.core.responses.CoreAuthnRequestProtocolVerifier
 import org.codice.compliance.verification.profile.SingleSignOnProfileVerifier
 import org.codice.security.saml.SamlProtocol.Binding.HTTP_POST
 import org.opensaml.saml.saml2.core.impl.AuthnContextClassRefBuilder
+import org.codice.security.sign.Encoder
 import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder
+import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA256
+import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256
 
 class PostSSOTest : StringSpec() {
     override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SSO))
@@ -126,6 +134,34 @@ class PostSSOTest : StringSpec() {
 
             // Main goal of this test is to do the NameIDPolicy verification in
             // CoreAuthnRequestProtocolVerifier
+            CoreAuthnRequestProtocolVerifier(authnRequest, samlResponseDom).apply {
+                verify()
+                verifyAssertionConsumerService(finalHttpResponse)
+            }
+            SingleSignOnProfileVerifier(samlResponseDom).apply {
+                verify()
+                verifyBinding(finalHttpResponse)
+            }
+        }
+
+        "DDF-Specific: POST AuthnRequest Using SHA256 for Signing Test".config(
+                enabled = runningDDFProfile()) {
+            useDSAServiceProvider()
+            val authnRequest = createDefaultAuthnRequest(HTTP_POST)
+
+            SimpleSign(ALGO_ID_SIGNATURE_RSA_SHA256, ALGO_ID_SIGNATURE_DSA_SHA256).signSamlObject(
+                    authnRequest)
+            val requestString = TestCommon.samlObjectToString(authnRequest)
+            requestString.debugPrettyPrintXml(SSOConstants.SAML_REQUEST)
+
+            val response = sendPostAuthnRequest(
+                    Encoder.encodePostMessage(SSOConstants.SAML_REQUEST, requestString))
+            BindingVerifier.verifyHttpStatusCode(response.statusCode)
+
+            val finalHttpResponse =
+                    getImplementation(IdpSSOResponder::class).getResponseForPostRequest(response)
+            val samlResponseDom = finalHttpResponse.getBindingVerifier().decodeAndVerify()
+
             CoreAuthnRequestProtocolVerifier(authnRequest, samlResponseDom).apply {
                 verify()
                 verifyAssertionConsumerService(finalHttpResponse)

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -42,7 +42,6 @@ import org.codice.security.sign.Encoder
 import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder
 import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA256
-import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256
 
 class PostSSOTest : StringSpec() {
     override val defaultTestCaseConfig = TestCaseConfig(tags = setOf(SSO))
@@ -149,7 +148,7 @@ class PostSSOTest : StringSpec() {
             useDSAServiceProvider()
             val authnRequest = createDefaultAuthnRequest(HTTP_POST)
 
-            SimpleSign(ALGO_ID_SIGNATURE_RSA_SHA256, ALGO_ID_SIGNATURE_DSA_SHA256).signSamlObject(
+            SimpleSign(ALGO_ID_SIGNATURE_DSA_SHA256).signSamlObject(
                     authnRequest)
             val requestString = TestCommon.samlObjectToString(authnRequest)
             requestString.debugPrettyPrintXml(SSOConstants.SAML_REQUEST)

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -38,7 +38,6 @@ import org.codice.security.saml.SamlProtocol.Binding.HTTP_REDIRECT
 import org.opensaml.saml.saml2.core.impl.AuthnContextClassRefBuilder
 import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder
 import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA256
-import org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256
 import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder
 
 class RedirectSSOTest : StringSpec() {
@@ -198,8 +197,7 @@ class RedirectSSOTest : StringSpec() {
             useDSAServiceProvider()
             val authnRequest = createDefaultAuthnRequest(HTTP_REDIRECT)
             val encodedRequest = encodeRedirectRequest(authnRequest)
-            val queryParams = SimpleSign(ALGO_ID_SIGNATURE_RSA_SHA256,
-                    ALGO_ID_SIGNATURE_DSA_SHA256).signUriString(
+            val queryParams = SimpleSign(ALGO_ID_SIGNATURE_DSA_SHA256).signUriString(
                     SAML_REQUEST,
                     encodedRequest,
                     null)

--- a/external/implementations/samlconf-ddf-impl/README.md
+++ b/external/implementations/samlconf-ddf-impl/README.md
@@ -8,7 +8,7 @@
 
 
 ## Steps to Test DDF's IDP
-* Start and install DDF
+* Start and install DDF. Note: If installing through the UI, the `users.attributes` file under `etc/` must be changed so that the admin email is `admin@localhost.local` instead of `admin@localhost`.
 * DDF does not support having multiple `EntityDescriptor` elements inside a `EntitiesDescriptor` element. In order to work around this:
     * From the `samlconf-sp-metadata.xml` file, copy the first `EntityDescriptor` element and all of its contents. Note: Make sure **not** to include the `EntitiesDescriptor` element or the second `EntityDescriptor` element.
     * Paste that into `AdminConsole -> Security -> Configuration -> IdPServer -> SP Metadata` as a new entry.


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
- Updated `SimpleSign` to be more similar to DDF's version
- Commented on every difference between our version of `SimpleSign` and DDF's version.
- Added a test for Redirect/POST SSO and Redirect/POST SLO which signs the request with SHA256withDSA
#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified