### PR TITLE
MAINT - Fixing unstable Redirect test

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -165,7 +165,7 @@ class TestCommon {
         /**
          * Converts the {@param samlObject} to a String
          */
-        private fun samlObjectToString(samlObject: XMLObject): String {
+        fun samlObjectToString(samlObject: XMLObject): String {
             val doc = DOMUtils.createDocument().apply {
                 appendChild(createElement("root"))
             }


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
- Change this particular test to cut the authnRequest in half before encoding rather than after. This will avoid errors like:
>19:11:10 [33msaml_1  |[0m   KotlinTest:RedirectSSOErrorTest:Bindings 3.4.3: Redirect Incomplete AuthnRequest In URL Query Test
19:11:10 [33msaml_1  |[0m     => java.lang.IllegalArgumentException: Malformed escape pair at index 299: /services/idp/login?SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1&SAMLRequest=jZJdb8IgFIb%2FCuEeKfjRltgmbmaZicsa7XaxO2ypkrTQcajZz1%2BtLrpdmF0Cz%2FucA4c5yKbmrVh0%2FmA26rNT4NECQDmvrXm0BrpGua1yR12ot806wQfvWxCUnoIHC15EcTymcCZg2KYAlrb9GUbL3qeNPMmu0bKs%2FqR02dLa7rXB6Mm6Qg3tJLiSNSiMVssEy%2&Signature=fiVa2eyopmcCp3C1%2Bgk1ntDmulaE9sQOt%2BxoEFpVIkARCCWVSOUxOur67V9gFPfe1Bx6hhhHz06oM19KwP1P0szBw7tBbPOKPP0hgvg%2FDGy%2BWDP1fSnQmUHCPvjlNvnKo2opo0xXJYeYIOgPQU9cacAaxtXxoJRqHJxHfxAVVt8nH5COOGB5CqWiV5WJQxJhdTxl15qO5jkm1bU9GFnfuLSuQnPKr943eF8yA3fcbXmfPZ35MihRi7KIE87x1e91u1DkFDcPzWgQcnHzdL6bi%2FOWA4%2FZUVsZ14qakiVC8l6pCZkcYR%2FgT4LGTk2%2B6VJ6fntuARNSH%2BlR1QKwG0clqw%3D%3D
#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified