### PR TITLE
MIANT - Added OASIS license

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,13 @@ To build this module you must run the docker task by executing `gradlew build do
 FICAM: https://www.idmanagement.gov/wp-content/uploads/sites/1171/uploads/SAML2_1.0.2_Functional_Reqs.pdf
 
 SAML: https://wiki.oasis-open.org/security/FrontPage
+
+## Copyright / License
+Copyright (c) Codice Foundation
+
+This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+<http://www.gnu.org/licenses/lgpl.html>.

--- a/deployment/distribution/src/main/resources/README.md
+++ b/deployment/distribution/src/main/resources/README.md
@@ -99,5 +99,15 @@ Additional Information
 
 To run this test kit against other Identity Providers, see the README.md file at https://github.com/connexta/saml-conformance.
 
+Copyright / License
+===================
+
 Copyright (c) Codice Foundation
+
+This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+<http://www.gnu.org/licenses/lgpl.html>.
 

--- a/deployment/distribution/src/main/resources/licenses/LICENSE.md
+++ b/deployment/distribution/src/main/resources/licenses/LICENSE.md
@@ -1,0 +1,6 @@
+Security Assertion Markup Language (SAML) Conformance Test Kit (CTK)
+Copyright Codice Foundation
+
+This product uses Security Assertion Markup Language (SAML) Specification documents developed by
+the Security Services Technical Committee of OASIS
+Licensed under the GNU General Public License, version 2

--- a/deployment/distribution/src/main/resources/licenses/OASIS.txt
+++ b/deployment/distribution/src/main/resources/licenses/OASIS.txt
@@ -1,0 +1,31 @@
+OASIS takes no position regarding the validity or scope of any intellectual property or other rights that
+might be claimed to pertain to the implementation or use of the technology described in this document or
+the extent to which any license under such rights might or might not be available; neither does it
+represent that it has made any effort to identify any such rights. Information on OASIS's procedures with
+respect to rights in OASIS specifications can be found at the OASIS website. Copies of claims of rights
+made available for publication and any assurances of licenses to be made available, or the result of an
+attempt made to obtain a general license or permission for the use of such proprietary rights by
+implementors or users of this specification, can be obtained from the OASIS Executive Director.
+
+OASIS invites any interested party to bring to its attention any copyrights, patents or patent applications,
+or other proprietary rights which may cover technology that may be required to implement this
+specification. Please address the information to the OASIS Executive Director.
+
+Copyright © OASIS Open 2005. All Rights Reserved.
+
+This document and translations of it may be copied and furnished to others, and derivative works that
+comment on or otherwise explain it or assist in its implementation may be prepared, copied, published
+and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice
+and this paragraph are included on all such copies and derivative works. However, this document itself
+may not be modified in any way, such as by removing the copyright notice or references to OASIS, except
+as needed for the purpose of developing OASIS specifications, in which case the procedures for
+copyrights defined in the OASIS Intellectual Property Rights document must be followed, or as required to
+translate it into languages other than English.
+
+The limited permissions granted above are perpetual and will not be revoked by OASIS or its successors
+or assigns.
+
+This document and the information contained herein is provided on an “AS IS” basis and OASIS
+DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR
+ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Added OASIS license:
- Looked at [DDF NOTICE](https://github.com/codice/ddf/blob/master/distribution/ddf-common/src/main/resources/NOTICE) and [DDF licenses](https://github.com/codice/ddf/tree/master/distribution/ddf-common/src/main/resources/licenses)
- Copied OASIS licenses from [_Appendix B. Notices_](https://www.oasis-open.org/committees/download.php/56776/sstc-saml-core-errata-2.0-wd-07.pdf) of the spec documents
- Got the GNU License from the bottom of the [_SAML Wiki Front Page_](https://wiki.oasis-open.org/security/FrontPage)
- Both files will be found in the distribution under `samlconf/conf/licenses`

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified