### PR TITLE
MAINT - Added a simplified README in distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # SAML Conformance Test Kit
 This project is intended to be a set of blackbox tests that verify the conformance of an IdP to the SAML V2.0 Standard Specification.
-It is currently a prototype being actively developed.
 
 > NOTE
 > 
@@ -9,8 +8,6 @@ It is currently a prototype being actively developed.
 > - It does not support proxying.
 >
 > - Only MUSTs from the specification are tested, currently.
-> 
-> - This test kit only support `RSAwithSHA1` and `DSAwithSHA1` algorithms for Redirect and XML Signatures.
 
 ## Building
 To build the project:
@@ -68,15 +65,16 @@ The `samlconf` script may take the following parameters:
            SAMLComplianceException will be thrown with an explanation of the error and a direct
            quote from the specification. Tests will not run if the corresponding
            endpoints do not exist in the IdP's metadata. All of the parameters
-           are optional and if they are not provided, the default values will use DDF's parameters.
+           are optional and if they are not provided, the default values will use
+           Distributed Data Framework (DDF)'s parameters. See the README.md file at
+           https://github.com/codice/ddf to learn more about DDF.
     
     OPTIONS
            -debug
-                Boolean for whether or not to enable debug mode which enables more logging.
-                The default value is false.
+                Enables debug mode which enables more logging. This mode is off by default.
 
            -ddf
-                Run the DDF profile. If provided runs the optional SAML V2.0 Standard
+                Runs the DDF profile. If provided runs the optional SAML V2.0 Standard
                 Specification rules required by DDF.
 
            -i path

--- a/deployment/distribution/src/main/resources/README.md
+++ b/deployment/distribution/src/main/resources/README.md
@@ -1,0 +1,103 @@
+<!--
+Copyright (c) Codice Foundation
+
+This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+General Public License as published by the Free Software Foundation, either
+version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+License is distributed along with this program and can be found at
+<http://www.gnu.org/licenses/lgpl.html>.
+-->
+
+
+Welcome to the Security Assertion Markup Language (SAML) Conformance Test Kit (CTK)
+===================================================================================
+The SAML Conformance Test Kit is a set of blackbox tests that verify the conformance of an
+Identity Provider (IdP) to the SAML V2.0 Standard Specification.
+
+Note following before running the tests:
+  * This test kit only supports SAML Version 2.0. All other version are not supported.
+  * This test kit does not support proxying.
+  * Only MUSTs from the SAML V2.0 Standard Specification are tested.
+  * Some MUSTs are hard to test. For a full list, visit
+  https://github.com/connexta/saml-conformance/blob/master/ctk/idp/coverage/NotTested.md
+  * This test kit includes built-in support for Keycloak and Distributed Data Framework (DDF).
+
+Getting Started
+===============
+For a SAML CTK source distribution, please read the README.md file at
+https://github.com/connexta/saml-conformance for instructions on building this test kit.
+
+How to Run
+==========
+* Unzip the distribution.
+* Run the executable at <distribution_home>/bin/samlconf (*NIX) or <distribution_home>/bin/samlconf.bat (Windows)
+
+The `samlconf` script may take the following parameters:
+
+    NAME
+           samlconf - Runs the SAML Conformance Tests against an IdP
+
+    SYNOPSIS
+           samlconf [arguments ...]
+
+    DESCRIPTION
+           Runs the SAML Conformance Tests which test the compliance of an IdP
+           to the SAML Specifications. If a compliance issue is identified, a
+           SAMLComplianceException will be thrown with an explanation of the error and a direct
+           quote from the specification. Tests will not run if the corresponding
+           endpoints do not exist in the IdP's metadata. All of the parameters
+           are optional and if they are not provided, the default values will use
+           Distributed Data Framework (DDF)'s parameters. See the README.md file at
+           https://github.com/codice/ddf to learn more about DDF.
+
+    OPTIONS
+           -debug
+                Enables debug mode which enables more logging. This mode is off by default.
+
+           -ddf
+                Runs the DDF profile. If provided runs the optional SAML V2.0 Standard
+                Specification rules required by DDF.
+
+           -i path
+                The path to the directory containing the implementation's plugin and metadata.
+                The default value is /implementations/ddf.
+
+           -l
+                When an error occurs, the SAML V2.0 Standard Specification requires an IdP to
+                respond with a 200 HTTP status code and a valid SAML response containing an
+                error <StatusCode>.
+                If the -l flag is given, this test kit will allow HTTP error status codes as
+                a valid error response (i.e. 400's and 500's).
+                If it is not given, this test kit will only verify that a valid SAML error
+                response is returned.
+
+           -u username:password
+                The username and password to use when logging in.
+                The default value is admin:admin.
+
+
+Identity Provider Support
+=========================
+This test kit includes built-in support for Keycloak and Distributed Data Framework (DDF).
+
+  * To run the test against Distributed Data Framework (DDF):
+    - Setup your DDF IdP.
+    - Configure your IdP with the test kit's Service Provider (SP) metadata from `<distribution_home>/conf/samlconf-sp-metadata.xml`.
+    - Run the `samlconf` script without a `-i` or with `-i <distribution_home>/implementations/ddf`.
+
+  * To run the test against Keycloak:
+    - Setup your Keycloak IdP.
+    - Configure your IdP with the test kit's Service Provider (SP) metadata from `<distribution_home>/conf/samlconf-sp-metadata.xml`.
+    - Run the `samlconf` script with `-i <distribution_home>/implementations/keycloak`.
+
+Additional Information
+=====================
+
+To run this test kit against other Identity Providers, see the README.md file at https://github.com/connexta/saml-conformance.
+
+Copyright (c) Codice Foundation
+


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.
Added a simplified README in distribution. 
- Current README won't be in the distribution and is specific to building and creating plugins.
- Used [DDF distro README](https://github.com/codice/ddf/blob/master/distribution/ddf-common/src/main/resources/README) as a template 

#### Checklist:
- [ ] SAML Spec Table of Contents documentation updated
- [ ] Unit Tests Added/Modified