### PR TITLE
MAINT - Added credentials for the publish task in Jenkins

### DIFF
--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -32,8 +32,11 @@ pipeline {
         stage('Deploy') {
             parallel {
                 stage ('Artifact Deploy') {
+                    environment {
+                        CODICE_DEPLOY = credentials('codice-deploy-creds') // any environment variable used for a credential automatically gets split into two like <VARNAME>_USR and <VARNAME>_PSW
+                    }
                     steps {
-                        sh './gradlew publish'
+                        sh './gradlew publish -Pcodice_deploy_username=$CODICE_DEPLOY_USR -Pcodice_deploy_password=$CODICE_DEPLOY_PSW'
                     }
                 }
                 stage ('Docker Deploy') {

--- a/deployment/distribution/build.gradle.kts
+++ b/deployment/distribution/build.gradle.kts
@@ -78,6 +78,23 @@ publishing {
     val snapshotUrl = "http://artifacts.codice.org/content/repositories/snapshots/"
     repositories {
         maven {
+            credentials {
+                // This will evaluate to an empty string if the property is not present
+                // (can be passed in via cli `-P` arg or via `~/.gradle/gradle.properties`
+                username = if (project.hasProperty("codice_deploy_username")) {
+                    project.property("codice_deploy_username") as String
+                } else {
+                    ""
+                }
+
+                // This will evaluate to an empty string if the property is not present
+                // (can be passed in via cli `-P` arg or via `~/.gradle/gradle.properties`
+                password = if (project.hasProperty("codice_deploy_password")) {
+                    project.property("codice_deploy_password") as String
+                } else {
+                    ""
+                }
+            }
             url = if (version.toString().endsWith("SNAPSHOT")) {
                 uri(snapshotUrl)
             } else {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ http://www.gnu.org/licenses/lgpl.html
 */
 // Build file
 rootProject.name = "saml-conformance"
+enableFeaturePreview("STABLE_PUBLISHING")
 
 include("library",
         "external:samlconf-plugins-api",


### PR DESCRIPTION
### Description of the Change
Currently the deploy is failing because it is unauthorized.
Added credentials in the publish task and modified the `DeployJenkinsfile` to be ale to deploy. 

### SAML V2.0 Specification Quote
N/A

### Verification Process
Verify that the deploy was sucessful.

### Checklist:
- [ ] Unit Tests Added/Modified
